### PR TITLE
fix: harden launch readiness and lifecycle coverage

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -7,6 +7,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { buildAdminUpdateUserProfileAuditEntry } from "@/lib/admin/users";
 
 const VALID_ROLES = ["student", "parent", "tutor", "admin"] as const;
 type Role = (typeof VALID_ROLES)[number];
@@ -98,7 +99,7 @@ const updateProfileSchema = z.object({
 
 /** Update a user's display name and WhatsApp number. */
 export async function updateUserProfile(userId: string, formData: FormData) {
-  await requireAdmin();
+  const adminUserId = await requireAdmin();
 
   const raw = {
     display_name: formData.get("display_name") as string,
@@ -122,13 +123,11 @@ export async function updateUserProfile(userId: string, formData: FormData) {
   if (error) throw new Error(`Failed to update profile: ${error.message}`);
 
   await admin.from("audit_logs").insert([
-    {
-      actor_user_id: userId,
-      action: "admin_update_user_profile",
-      entity_type: "user_profiles",
-      entity_id: userId,
-      details: { display_name: parsed.data.display_name },
-    },
+    buildAdminUpdateUserProfileAuditEntry({
+      actorUserId: adminUserId,
+      targetUserId: userId,
+      displayName: parsed.data.display_name,
+    }),
   ]);
 
   revalidatePath("/admin/users");

--- a/app/admin/matches/[id]/MatchActions.tsx
+++ b/app/admin/matches/[id]/MatchActions.tsx
@@ -260,10 +260,11 @@ export function EditMatchForm({
       <input type="hidden" name="matchId" value={matchId} />
 
       <div>
-        <label className="block text-sm font-medium text-[#121212]/80">
+        <label htmlFor="edit-match-meet-link" className="block text-sm font-medium text-[#121212]/80">
           Google Meet Link
         </label>
         <input
+          id="edit-match-meet-link"
           type="url"
           name="meetLink"
           defaultValue={currentMeetLink ?? ''}
@@ -273,10 +274,11 @@ export function EditMatchForm({
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-[#121212]/80">
+        <label htmlFor="edit-match-timezone" className="block text-sm font-medium text-[#121212]/80">
           Schedule Timezone
         </label>
         <input
+          id="edit-match-timezone"
           type="text"
           name="timezone"
           defaultValue={currentSchedule?.timezone ?? ''}
@@ -291,8 +293,9 @@ export function EditMatchForm({
         </label>
         <div className="flex flex-wrap gap-3">
           {DAY_OPTIONS.map(({ label, value }) => (
-            <label key={value} className="flex cursor-pointer items-center gap-1.5 text-sm">
+            <label htmlFor={`edit-match-day-${value}`} key={value} className="flex cursor-pointer items-center gap-1.5 text-sm">
               <input
+                id={`edit-match-day-${value}`}
                 type="checkbox"
                 name="days"
                 value={value}
@@ -306,10 +309,11 @@ export function EditMatchForm({
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-[#121212]/80">
+        <label htmlFor="edit-match-time" className="block text-sm font-medium text-[#121212]/80">
           Start Time
         </label>
         <input
+          id="edit-match-time"
           type="time"
           name="time"
           defaultValue={currentSchedule?.time ?? ''}

--- a/app/admin/matches/[id]/page.tsx
+++ b/app/admin/matches/[id]/page.tsx
@@ -61,10 +61,13 @@ type MatchDetail = {
 
 export default async function AdminMatchDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>
+  searchParams: Promise<{ assigned?: string }>
 }) {
   const { id } = await params
+  const { assigned } = await searchParams
   const admin = createAdminClient()
 
   const { data: matchData } = await admin
@@ -160,6 +163,15 @@ export default async function AdminMatchDetailPage({
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
+      {assigned === '1' && (
+        <div className="border-2 border-[#121212] bg-white px-6 py-4 text-[#121212]">
+          <p className="font-semibold">Tutor assigned successfully.</p>
+          <p className="mt-1 text-sm text-[#121212]/60">
+            The request is now matched and ready for session generation or follow-up updates.
+          </p>
+        </div>
+      )}
+
       {/* Back link */}
       <div className="flex items-center gap-4">
         <Link

--- a/app/admin/requests/[id]/AssignTutorForm.tsx
+++ b/app/admin/requests/[id]/AssignTutorForm.tsx
@@ -242,11 +242,12 @@ export function AssignTutorForm({
           <input type="hidden" name="tutorUserId" value={selectedTutorId} />
 
           <div>
-            <label className="block text-sm font-medium text-[#121212]/80">
+            <label htmlFor="assign-meet-link" className="block text-sm font-medium text-[#121212]/80">
               Google Meet Link{' '}
               <span className="font-normal text-[#121212]/40">(optional — can be added later)</span>
             </label>
             <input
+              id="assign-meet-link"
               type="url"
               name="meetLink"
               placeholder="https://meet.google.com/xxx-xxxx-xxx"
@@ -255,11 +256,12 @@ export function AssignTutorForm({
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-[#121212]/80">
+            <label htmlFor="assign-timezone" className="block text-sm font-medium text-[#121212]/80">
               Schedule Timezone{' '}
               <span className="font-normal text-[#121212]/40">(optional — defaults to student&apos;s)</span>
             </label>
             <input
+              id="assign-timezone"
               type="text"
               name="timezone"
               defaultValue={requestTimezone}
@@ -275,8 +277,9 @@ export function AssignTutorForm({
             </label>
             <div className="flex flex-wrap gap-3">
               {DAY_OPTIONS.map(({ label, value }) => (
-                <label key={value} className="flex cursor-pointer items-center gap-1.5 text-sm">
+                <label htmlFor={`assign-day-${value}`} key={value} className="flex cursor-pointer items-center gap-1.5 text-sm">
                   <input
+                    id={`assign-day-${value}`}
                     type="checkbox"
                     name="days"
                     value={value}
@@ -289,11 +292,12 @@ export function AssignTutorForm({
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-[#121212]/80">
+            <label htmlFor="assign-time" className="block text-sm font-medium text-[#121212]/80">
               Start Time{' '}
               <span className="font-normal text-[#121212]/40">(optional — 24 h format)</span>
             </label>
             <input
+              id="assign-time"
               type="time"
               name="time"
               className="mt-1 border border-[#B0B0B0] px-3 py-2 text-sm focus:border-[#1040C0] focus:outline-none"

--- a/app/admin/requests/actions.ts
+++ b/app/admin/requests/actions.ts
@@ -6,6 +6,7 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { requireAdmin } from '@/lib/auth/requireAdmin'
 import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
 import type { Json } from '@/lib/supabase/database.types'
 import type { Database } from '@/lib/supabase/database.types'
 
@@ -26,6 +27,8 @@ export async function assignTutor({
     duration_mins: number
   }
 }): Promise<{ error?: string; matchId?: string }> {
+  let assignedMatchId: string | null = null
+
   try {
     const adminUserId = await requireAdmin()
     const admin = createAdminClient()
@@ -92,10 +95,13 @@ export async function assignTutor({
     revalidatePath(`/admin/requests/${requestId}`)
     revalidatePath('/admin/requests')
     revalidatePath('/admin/matches')
-    return { matchId: match.id }
+    revalidatePath(`/admin/matches/${match.id}`)
+    assignedMatchId = match.id
   } catch (err) {
     return { error: err instanceof Error ? err.message : 'An unexpected error occurred.' }
   }
+
+  redirect(`/admin/matches/${assignedMatchId}?assigned=1`)
 }
 
 /** Update match.tutor_user_id to a new tutor and write audit log (history kept). */

--- a/app/admin/sessions/SessionFilters.tsx
+++ b/app/admin/sessions/SessionFilters.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { useRef } from 'react'
+import { getAdminSessionStatusFilterOptions } from '@/lib/admin/sessions'
 
 // ── Student-picker search bar ─────────────────────────────────────────────────
 
@@ -83,14 +84,7 @@ export function SessionViewControls({
     { value: 'past', label: 'Past', count: pastCount },
   ]
 
-  const statuses = [
-    { value: '', label: 'All statuses' },
-    { value: 'scheduled', label: 'Scheduled' },
-    { value: 'done', label: 'Done' },
-    { value: 'rescheduled', label: 'Rescheduled' },
-    { value: 'no_show_student', label: 'No-show (student)' },
-    { value: 'no_show_tutor', label: 'No-show (tutor)' },
-  ]
+  const statuses = getAdminSessionStatusFilterOptions()
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3">

--- a/app/admin/sessions/page.tsx
+++ b/app/admin/sessions/page.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link'
 import { CopyMessageButton } from '@/components/CopyMessageButton'
 import { WhatsAppLink } from '@/components/WhatsAppLink'
 import { templates } from '@/lib/whatsapp/templates'
+import { resolveAdminSessionStatusFilter } from '@/lib/admin/sessions'
 
 const ADMIN_TIMEZONE = 'Asia/Karachi'
 const IMPOSSIBLE_ID = '00000000-0000-0000-0000-000000000000'
@@ -30,6 +31,7 @@ export default async function AdminSessionsPage({
   const childParam = params.child // undefined = no filter, '' = self-request, name = parent's child
   const view = (params.view === 'past' ? 'past' : 'upcoming') as SessionView
   const filterStatus = params.status ?? ''
+  const resolvedStatusFilters = resolveAdminSessionStatusFilter(filterStatus)
   const studentSearch = params.search ?? ''
 
   const admin = createAdminClient()
@@ -291,8 +293,10 @@ export default async function AdminSessionsPage({
     .in('match_id', safeMatchIds)
     .order('scheduled_start_utc', { ascending: true })
 
-  if (filterStatus) {
-    sessionsQuery = sessionsQuery.eq('status', filterStatus as SessionStatus)
+  if (resolvedStatusFilters.length === 1) {
+    sessionsQuery = sessionsQuery.eq('status', resolvedStatusFilters[0] as SessionStatus)
+  } else if (resolvedStatusFilters.length > 1) {
+    sessionsQuery = sessionsQuery.in('status', resolvedStatusFilters)
   }
 
   const { data: sessionsData } = await sessionsQuery

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -9,6 +9,7 @@ import { WhatsAppLink } from '@/components/WhatsAppLink'
 import { AdminPagination, PAGE_SIZE } from '@/components/AdminPagination'
 import { UserFilters } from './UserFilters'
 import { DeleteUserButton } from './DeleteUserButton'
+import { getAdminUserPaymentBadge, getHighestPriorityPaymentStatus } from '@/lib/admin/users'
 
 const ALL_ROLES = ['student', 'parent', 'tutor', 'admin'] as const
 type Role = (typeof ALL_ROLES)[number]
@@ -163,15 +164,11 @@ export default async function AdminUsersPage({
     }
   }
 
-  // Best payment status per user: verified > pending > rejected
-  const PAYMENT_RANK: Record<string, number> = { verified: 3, pending: 2, rejected: 1 }
   const paymentByUser = new Map<string, string>()
   for (const pay of userPayments ?? []) {
     const uid = pay.payer_user_id as string
-    const existing = paymentByUser.get(uid)
-    const existingRank = existing ? (PAYMENT_RANK[existing] ?? 0) : 0
-    const newRank = PAYMENT_RANK[pay.status as string] ?? 0
-    if (newRank > existingRank) paymentByUser.set(uid, pay.status as string)
+    const nextStatus = getHighestPriorityPaymentStatus([paymentByUser.get(uid), pay.status as string])
+    if (nextStatus) paymentByUser.set(uid, nextStatus)
   }
 
   const filtersActive = !!(activeSearch || activeLevel || activeSubject || activePayment)
@@ -412,12 +409,7 @@ function RequestStatusBadge({ status }: { status: string }) {
 }
 
 function PaymentBadge({ status }: { status: string }) {
-  const map: Record<string, { label: string; cls: string }> = {
-    verified: { label: 'Verified', cls: 'bg-green-100 text-green-800 border border-green-300' },
-    pending: { label: 'Pending', cls: 'bg-yellow-100 text-yellow-800 border border-yellow-300' },
-    rejected: { label: 'Rejected', cls: 'bg-red-100 text-red-800 border border-red-300' },
-  }
-  const cfg = map[status] ?? { label: status, cls: 'bg-[#E0E0E0] text-[#121212]/60' }
+  const cfg = getAdminUserPaymentBadge(status)
   return (
     <span
       className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${cfg.cls}`}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -4,14 +4,17 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import { NextResponse, type NextRequest } from 'next/server'
-import { safeNext } from '@/lib/auth/utils'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { safeNext, shouldPromoteOAuthParentSignup } from '@/lib/auth/utils'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
-  const { searchParams, origin } = new URL(request.url)
+  const { searchParams, origin } = request.nextUrl
   const code = searchParams.get('code')
   const next = safeNext(searchParams.get('next'))
+  const flow = searchParams.get('flow')
+  const accountType = searchParams.get('account_type')
 
   if (code) {
     const cookieStore = await cookies()
@@ -40,11 +43,38 @@ export async function GET(request: NextRequest) {
       } = await supabase.auth.getUser()
 
       if (user) {
-        const { data: profile } = await supabase
-          .from('user_profiles')
-          .select('whatsapp_number')
-          .eq('user_id', user.id)
-          .single()
+        const [{ data: profile }, { data: roleRows }] = await Promise.all([
+          supabase
+            .from('user_profiles')
+            .select('primary_role, whatsapp_number, created_at')
+            .eq('user_id', user.id)
+            .single(),
+          supabase.from('user_roles').select('role').eq('user_id', user.id),
+        ])
+
+        if (
+          profile &&
+          shouldPromoteOAuthParentSignup({
+            flow,
+            accountType,
+            primaryRole: profile.primary_role,
+            assignedRoles: (roleRows ?? []).map((row) => row.role),
+            whatsappNumber: profile.whatsapp_number,
+            profileCreatedAt: profile.created_at,
+          })
+        ) {
+          const admin = createAdminClient()
+          const [{ error: profileUpdateError }, { error: parentRoleError }, { error: removeStudentError }] =
+            await Promise.all([
+              admin.from('user_profiles').update({ primary_role: 'parent' }).eq('user_id', user.id),
+              admin.from('user_roles').upsert({ user_id: user.id, role: 'parent' }),
+              admin.from('user_roles').delete().eq('user_id', user.id).eq('role', 'student'),
+            ])
+
+          if (profileUpdateError || parentRoleError || removeStudentError) {
+            return NextResponse.redirect(`${origin}/auth/sign-in?error=auth_callback_failed`)
+          }
+        }
 
         // New users who haven't set their WhatsApp number yet go to profile-setup
         if (!profile?.whatsapp_number) {

--- a/app/auth/sign-in/SignInForm.tsx
+++ b/app/auth/sign-in/SignInForm.tsx
@@ -10,7 +10,7 @@ import { z } from 'zod'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
-import { safeNext } from '@/lib/auth/utils'
+import { buildAuthCallbackUrl, safeNext } from '@/lib/auth/utils'
 import {
   BauhausLogo,
   BauhausLabel,
@@ -58,14 +58,11 @@ export function SignInForm() {
   async function signInWithGoogle() {
     setGoogleLoading(true)
     const supabase = createClient()
-    const baseRedirect = `${window.location.origin}/auth/callback`
-    const redirectTo =
-      next !== '/dashboard'
-        ? `${baseRedirect}?next=${encodeURIComponent(next)}`
-        : baseRedirect
     await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: { redirectTo },
+      options: {
+        redirectTo: buildAuthCallbackUrl(window.location.origin, { next }),
+      },
     })
   }
 

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
+import { buildAuthCallbackUrl } from '@/lib/auth/utils'
 import {
   BauhausLogo,
   BauhausLabel,
@@ -100,7 +101,12 @@ export default function SignUpPage() {
     const supabase = createClient()
     await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: { redirectTo: `${window.location.origin}/auth/callback` },
+      options: {
+        redirectTo: buildAuthCallbackUrl(window.location.origin, {
+          flow: 'signup',
+          accountType: accountType === 'parent' ? 'parent' : 'student',
+        }),
+      },
     })
   }
 

--- a/app/auth/verify/page.tsx
+++ b/app/auth/verify/page.tsx
@@ -3,6 +3,7 @@
 
 import Link from 'next/link'
 import { BauhausLogo, BauhausGeometricPanel } from '@/components/ui/bauhaus'
+import { ResendVerificationButton } from './ResendButton'
 
 export default function VerifyPage() {
   return (
@@ -49,6 +50,8 @@ export default function VerifyPage() {
               <li>The link expires after 1 hour</li>
             </ul>
           </div>
+
+          <ResendVerificationButton />
 
           <p className="mt-6 text-sm text-[#121212]/60">
             Wrong email?{' '}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -32,6 +32,7 @@ export default async function DashboardLayout({
   if (profile?.primary_role === 'tutor') redirect('/tutor')
 
   const displayName = profile?.display_name ?? user.email ?? 'Student'
+  const dashboardRoleLabel = profile?.primary_role === 'parent' ? 'Parent' : 'Student'
 
   const navLinks = [
     { href: '/dashboard', label: 'Dashboard' },
@@ -64,7 +65,7 @@ export default async function DashboardLayout({
               CorvEd
             </Link>
             <span className="border-2 border-[#1040C0] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-widest text-[#1040C0]">
-              Student
+              {dashboardRoleLabel}
             </span>
           </div>
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -51,6 +51,7 @@ export default async function DashboardPage() {
   if (role === 'tutor') redirect('/tutor')
 
   const userTimezone = profile?.timezone ?? 'UTC'
+  const dashboardRoleLabel = role === 'parent' ? 'Parent' : 'Student'
 
   // Fetch next session and requests in parallel (both independent)
   const [{ data: nextSessionData }, { data: requests }] = await Promise.all([
@@ -183,7 +184,7 @@ export default async function DashboardPage() {
         {/* Header row */}
         <div className="flex items-start justify-between border-b-4 border-[#121212] pb-4">
           <div>
-            <p className="text-xs font-bold uppercase tracking-widest text-[#121212]/50">Student</p>
+            <p className="text-xs font-bold uppercase tracking-widest text-[#121212]/50">{dashboardRoleLabel}</p>
             <h1 className="text-3xl font-black uppercase tracking-tighter text-[#121212] leading-tight">
               Dashboard
             </h1>

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -29,6 +29,42 @@ test.describe("Auth Pages", () => {
     await expect(page.getByLabel("Password", { exact: true })).toBeVisible();
   });
 
+  test("sign-up parent tab shows parent-specific fields and CTA", async ({ page }) => {
+    await page.goto("/auth/sign-up");
+    await page.getByRole("button", { name: "Parent" }).click();
+
+    await expect(page.getByLabel(/child's full name/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Create Parent Account", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /sign up with google/i }),
+    ).toBeVisible();
+  });
+
+  test("sign-up tutor tab routes applicants to the tutor application", async ({
+    page,
+  }) => {
+    await page.goto("/auth/sign-up");
+    await page.getByRole("button", { name: "Tutor" }).click();
+
+    await expect(
+      page.getByRole("link", { name: /go to tutor application/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /sign up with google/i }),
+    ).toHaveCount(0);
+  });
+
+  test("verify page includes resend verification controls", async ({ page }) => {
+    await page.goto("/auth/verify");
+    await expect(page.getByText("Didn't receive it?")).toBeVisible();
+    await expect(page.getByPlaceholder(/re-enter your email/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Resend", exact: true }),
+    ).toBeVisible();
+  });
+
   test("forgot-password page renders form", async ({ page }) => {
     await page.goto("/auth/forgot-password");
     await expect(page.getByLabel(/email/i)).toBeVisible();

--- a/e2e/fixtures/payment-proof.pdf
+++ b/e2e/fixtures/payment-proof.pdf
@@ -1,0 +1,23 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 12 Tf
+20 100 Td
+(CorvEd Test Payment Proof) Tj
+ET
+endstream
+endobj
+trailer
+<< /Root 1 0 R >>
+%%EOF

--- a/e2e/lifecycle.spec.ts
+++ b/e2e/lifecycle.spec.ts
@@ -1,0 +1,388 @@
+import path from 'node:path'
+
+import { test, expect, type Browser, type Page } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import { DateTime } from 'luxon'
+
+import type { Database } from '@/lib/supabase/database.types'
+
+const proofFixturePath = path.resolve(__dirname, 'fixtures', 'payment-proof.pdf')
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+function createServiceClient() {
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    throw new Error('Local Supabase service-role env is not configured for lifecycle tests.')
+  }
+
+  return createClient<Database>(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+async function signIn(page: Page, email: string, password: string, expectedUrl: RegExp) {
+  await page.goto('/auth/sign-in')
+  await page.getByLabel(/email/i).fill(email)
+  await page.getByLabel('Password').fill(password)
+  await page.getByRole('button', { name: 'Sign In', exact: true }).click()
+  await expect(page).toHaveURL(expectedUrl, { timeout: 15_000 })
+}
+
+async function createAuthenticatedPage(
+  browser: Browser,
+  email: string,
+  password: string,
+  expectedUrl: RegExp,
+) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await signIn(page, email, password, expectedUrl)
+  return { context, page }
+}
+
+async function createSeededUser(params: {
+  email: string
+  password: string
+  displayName: string
+  whatsapp: string
+  role: 'student' | 'tutor'
+}) {
+  const admin = createServiceClient()
+  const { data, error } = await admin.auth.admin.createUser({
+    email: params.email,
+    password: params.password,
+    email_confirm: true,
+    user_metadata: {
+      name: params.displayName,
+      role: params.role,
+      timezone: 'Asia/Karachi',
+    },
+  })
+
+  if (error || !data.user) {
+    throw new Error(`Failed to create ${params.role} test user: ${error?.message ?? 'unknown error'}`)
+  }
+
+  const userId = data.user.id
+  await admin
+    .from('user_profiles')
+    .update({
+      display_name: params.displayName,
+      whatsapp_number: params.whatsapp,
+      timezone: 'Asia/Karachi',
+      primary_role: params.role,
+    })
+    .eq('user_id', userId)
+
+  await admin.from('user_roles').upsert({ user_id: userId, role: params.role })
+
+  return { id: userId, email: params.email, password: params.password, displayName: params.displayName }
+}
+
+async function createSeededAdmin(params: {
+  email: string
+  password: string
+  displayName: string
+  whatsapp: string
+}) {
+  const admin = createServiceClient()
+  const { data, error } = await admin.auth.admin.createUser({
+    email: params.email,
+    password: params.password,
+    email_confirm: true,
+    user_metadata: {
+      name: params.displayName,
+      role: 'student',
+      timezone: 'Asia/Karachi',
+    },
+  })
+
+  if (error || !data.user) {
+    throw new Error(`Failed to create admin test user: ${error?.message ?? 'unknown error'}`)
+  }
+
+  const userId = data.user.id
+  await admin
+    .from('user_profiles')
+    .update({
+      display_name: params.displayName,
+      whatsapp_number: params.whatsapp,
+      timezone: 'Asia/Karachi',
+      primary_role: 'admin',
+    })
+    .eq('user_id', userId)
+
+  await admin.from('user_roles').upsert({ user_id: userId, role: 'admin' })
+
+  return { id: userId, email: params.email, password: params.password, displayName: params.displayName }
+}
+
+async function ensureSubject() {
+  const admin = createServiceClient()
+  const { data, error } = await admin
+    .from('subjects')
+    .upsert(
+      {
+        code: 'math',
+        name: 'Mathematics',
+        active: true,
+        sort_order: 1,
+      },
+      { onConflict: 'code' },
+    )
+    .select('id, name')
+    .single()
+
+  if (error || !data) {
+    throw new Error(`Failed to ensure Mathematics subject: ${error?.message ?? 'unknown error'}`)
+  }
+
+  return data
+}
+
+async function seedApprovedTutor(tutorUserId: string, subjectId: number) {
+  const admin = createServiceClient()
+
+  await admin.from('tutor_profiles').upsert({
+    tutor_user_id: tutorUserId,
+    approved: true,
+    bio: 'Lifecycle test tutor',
+    timezone: 'Asia/Karachi',
+    experience_years: 4,
+    education: 'BS Mathematics',
+    teaching_approach: 'Exam-focused',
+  })
+
+  await admin.from('tutor_subjects').upsert({
+    tutor_user_id: tutorUserId,
+    subject_id: subjectId,
+    level: 'o_levels',
+  })
+
+  await admin.from('tutor_availability').upsert({
+    tutor_user_id: tutorUserId,
+    windows: [
+      { day: 1, start: '16:00', end: '20:00' },
+      { day: 3, start: '16:00', end: '20:00' },
+      { day: 5, start: '16:00', end: '20:00' },
+    ],
+  })
+}
+
+test.describe('Authenticated Lifecycle', () => {
+  test('student request, payment, matching, session generation, and tutor completion work end to end', async ({
+    browser,
+  }, testInfo) => {
+    test.setTimeout(180_000)
+    test.slow()
+    test.skip(testInfo.project.name === 'mobile', 'Full lifecycle is covered on desktop only.')
+
+    const unique = Date.now().toString()
+    const password = 'Passw0rd!123'
+    const studentName = `Lifecycle Student ${unique}`
+    const adminName = `Lifecycle Admin ${unique}`
+    const tutorName = `Lifecycle Tutor ${unique}`
+
+    const subject = await ensureSubject()
+    const student = await createSeededUser({
+      email: `student.${unique}@corved.test`,
+      password,
+      displayName: studentName,
+      whatsapp: '+923001110001',
+      role: 'student',
+    })
+    const adminUser = await createSeededAdmin({
+      email: `admin.${unique}@corved.test`,
+      password,
+      displayName: adminName,
+      whatsapp: '+923001110002',
+    })
+    const tutor = await createSeededUser({
+      email: `tutor.${unique}@corved.test`,
+      password,
+      displayName: tutorName,
+      whatsapp: '+923001110003',
+      role: 'tutor',
+    })
+    await seedApprovedTutor(tutor.id, subject.id)
+    const admin = createServiceClient()
+
+    const karachiDay = DateTime.now().setZone('Asia/Karachi').weekday % 7
+    const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+    const scheduleDayLabel = dayLabels[karachiDay]
+
+    const studentSession = await createAuthenticatedPage(browser, student.email, student.password, /\/dashboard/)
+    const studentPage = studentSession.page
+
+    await studentPage.goto('/dashboard/requests/new')
+    await studentPage.locator('section').filter({ hasText: 'Step 2' }).locator('select').nth(0).selectOption('o_levels')
+    await studentPage.locator('section').filter({ hasText: 'Step 2' }).locator('select').nth(1).selectOption(String(subject.id))
+    await studentPage.getByRole('button', { name: /8\s+sessions\/month/i }).click()
+    await studentPage.getByRole('button', { name: /Mon Evening|Tue Evening|Wed Evening|Thu Evening|Fri Evening|Sat Evening|Sun Evening/i }).first().click()
+    await studentPage.getByRole('button', { name: /submit request/i }).click()
+
+    let requestId: string | null = null
+    await expect
+      .poll(async () => {
+        const { data } = await admin
+          .from('requests')
+          .select('id, status')
+          .eq('created_by_user_id', student.id)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle()
+
+        requestId = data?.id ?? null
+        return data?.status ?? null
+      }, { timeout: 15_000 })
+      .toBe('new')
+
+    expect(requestId).toBeTruthy()
+    await studentPage.goto(`/dashboard/requests/${requestId}`)
+    await studentPage.getByRole('link', { name: /Continue to Payment/i }).click()
+    await expect(studentPage).toHaveURL(/\/dashboard\/packages\/new/)
+
+    await studentPage.getByRole('button', { name: /Continue to payment/i }).click()
+    await expect(studentPage).toHaveURL(/\/dashboard\/packages\/.+/)
+    await studentPage.getByLabel(/Transaction reference/i).fill(`TRX-${unique}`)
+    await studentPage.setInputFiles('#payment-proof', proofFixturePath)
+    await studentPage.getByRole('button', { name: /I have made the transfer/i }).click()
+
+    let requestStatus: string | null = null
+    await expect
+      .poll(async () => {
+        const { data } = await admin
+          .from('requests')
+          .select('status')
+          .eq('id', requestId)
+          .single()
+
+        requestStatus = data?.status ?? null
+        return requestStatus
+      }, { timeout: 15_000 })
+      .toBe('payment_pending')
+
+    const { data: request } = await admin.from('requests').select('id, status').eq('id', requestId).single()
+    expect(request?.status).toBe('payment_pending')
+
+    let paymentId: string | null = null
+    await expect
+      .poll(async () => {
+        const { data } = await admin
+          .from('payments')
+          .select('id, package_id, status')
+          .eq('payer_user_id', student.id)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle()
+
+        paymentId = data?.id ?? null
+        return data?.status ?? null
+      }, { timeout: 15_000 })
+      .toBe('pending')
+
+    const { data: payment } = await admin
+      .from('payments')
+      .select('id, package_id, status')
+      .eq('id', paymentId)
+      .single()
+    expect(payment?.status).toBe('pending')
+
+    const adminSession = await createAuthenticatedPage(browser, adminUser.email, adminUser.password, /\/admin/)
+    const adminPage = adminSession.page
+
+    await adminPage.goto('/admin/payments?filter=pending')
+    const paymentCard = adminPage.locator('div').filter({ hasText: studentName }).filter({ hasText: 'PKR' }).first()
+    await expect(paymentCard).toBeVisible()
+    await paymentCard.getByRole('button', { name: /Mark Paid/i }).first().click()
+    await expect.poll(async () => {
+      const { data } = await admin
+        .from('payments')
+        .select('status')
+        .eq('id', payment!.id)
+        .single()
+      return data?.status ?? null
+    }).toBe('paid')
+    await expect.poll(async () => {
+      const { data } = await admin
+        .from('requests')
+        .select('status')
+        .eq('id', request!.id)
+        .single()
+      return data?.status ?? null
+    }).toBe('ready_to_match')
+
+    await adminPage.goto('/admin/requests?status=ready_to_match')
+    const requestRow = adminPage.getByRole('row').filter({ hasText: studentName })
+    await expect(requestRow).toBeVisible()
+    await requestRow.getByRole('link', { name: /Match/i }).click()
+
+    const tutorCard = adminPage.locator('div').filter({ hasText: tutorName }).first()
+    await expect(tutorCard).toBeVisible()
+    await tutorCard.locator('input[type="radio"]').first().check()
+    await expect(adminPage.getByText('Assignment Details')).toBeVisible()
+    await adminPage.getByLabel(/Google Meet Link/i).fill('https://meet.google.com/lifecycle-test')
+    await adminPage.getByLabel(/Schedule Timezone/i).fill('Asia/Karachi')
+    await adminPage.getByLabel(scheduleDayLabel).check()
+    await adminPage.getByLabel(/Start Time/i).fill('10:00')
+    await adminPage.getByRole('button', { name: /Assign Tutor/i }).click()
+    await expect(adminPage).toHaveURL(/\/admin\/matches\/.+assigned=1/)
+    await expect(adminPage.getByText(/Tutor assigned successfully/i)).toBeVisible()
+
+    await adminPage.getByRole('button', { name: /Generate Sessions/i }).click()
+    await expect(adminPage.getByText(/generated successfully/i)).toBeVisible()
+
+    const { data: match } = await admin
+      .from('matches')
+      .select('id, request_id')
+      .eq('request_id', request!.id)
+      .single()
+    expect(match?.id).toBeTruthy()
+
+    const { data: sessions } = await admin
+      .from('sessions')
+      .select('id, scheduled_start_utc')
+      .eq('match_id', match!.id)
+      .order('scheduled_start_utc', { ascending: true })
+    expect((sessions ?? []).length).toBeGreaterThan(0)
+
+    const firstSession = sessions![0]
+    const pastStart = DateTime.now().minus({ hours: 2 }).toUTC().toISO()
+    const pastEnd = DateTime.now().minus({ hours: 1 }).toUTC().toISO()
+    await admin
+      .from('sessions')
+      .update({
+        scheduled_start_utc: pastStart!,
+        scheduled_end_utc: pastEnd!,
+        status: 'scheduled',
+      })
+      .eq('id', firstSession.id)
+
+    const tutorSession = await createAuthenticatedPage(browser, tutor.email, tutor.password, /\/tutor/)
+    const tutorPage = tutorSession.page
+    await tutorPage.goto('/tutor/sessions?view=past')
+    const tutorCardForStudent = tutorPage.locator('div').filter({ hasText: studentName }).first()
+    await expect(tutorCardForStudent).toBeVisible()
+    await tutorCardForStudent.getByRole('button', { name: /Mark Session/i }).click()
+    await tutorCardForStudent.getByRole('button', { name: 'Submit', exact: true }).click()
+    await expect(tutorPage.getByText('Session updated successfully')).toBeVisible()
+
+    const { data: activePackage } = await admin
+      .from('packages')
+      .select('id, sessions_used, status')
+      .eq('id', payment!.package_id)
+      .single()
+    expect(activePackage?.status).toBe('active')
+    expect(activePackage?.sessions_used).toBe(1)
+
+    await studentPage.goto('/dashboard')
+    await studentPage.reload()
+    await expect(studentPage.getByText('1 of 8 sessions used')).toBeVisible()
+    await expect(studentPage.getByText('7 of 8')).toBeVisible()
+
+    await tutorSession.context.close()
+    await adminSession.context.close()
+    await studentSession.context.close()
+  })
+})

--- a/lib/__tests__/auth-utils.test.ts
+++ b/lib/__tests__/auth-utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildAuthCallbackUrl,
+  safeNext,
+  shouldPromoteOAuthParentSignup,
+} from '@/lib/auth/utils'
+
+describe('safeNext', () => {
+  test('falls back to dashboard for invalid redirect targets', () => {
+    expect(safeNext(null)).toBe('/dashboard')
+    expect(safeNext('dashboard')).toBe('/dashboard')
+    expect(safeNext('//evil.example')).toBe('/dashboard')
+  })
+
+  test('accepts relative in-app redirects', () => {
+    expect(safeNext('/dashboard/requests')).toBe('/dashboard/requests')
+  })
+})
+
+describe('buildAuthCallbackUrl', () => {
+  test('adds signup intent for parent google signup', () => {
+    expect(
+      buildAuthCallbackUrl('https://corved.test', {
+        flow: 'signup',
+        accountType: 'parent',
+      }),
+    ).toBe('https://corved.test/auth/callback?flow=signup&account_type=parent')
+  })
+
+  test('preserves next for sign-in redirects', () => {
+    expect(
+      buildAuthCallbackUrl('https://corved.test', {
+        next: '/dashboard/sessions',
+      }),
+    ).toBe('https://corved.test/auth/callback?next=%2Fdashboard%2Fsessions')
+  })
+})
+
+describe('shouldPromoteOAuthParentSignup', () => {
+  test('promotes a fresh parent signup that still has the default student role', () => {
+    expect(
+      shouldPromoteOAuthParentSignup({
+        flow: 'signup',
+        accountType: 'parent',
+        primaryRole: 'student',
+        assignedRoles: ['student'],
+        whatsappNumber: null,
+        profileCreatedAt: '2026-04-08T11:58:00.000Z',
+        now: new Date('2026-04-08T12:00:00.000Z'),
+      }),
+    ).toBe(true)
+  })
+
+  test('does not promote existing or already-parent profiles', () => {
+    expect(
+      shouldPromoteOAuthParentSignup({
+        flow: 'signup',
+        accountType: 'parent',
+        primaryRole: 'student',
+        assignedRoles: ['student'],
+        whatsappNumber: null,
+        profileCreatedAt: '2026-04-08T11:45:00.000Z',
+        now: new Date('2026-04-08T12:00:00.000Z'),
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldPromoteOAuthParentSignup({
+        flow: 'signup',
+        accountType: 'parent',
+        primaryRole: 'parent',
+        assignedRoles: ['parent'],
+        whatsappNumber: null,
+        profileCreatedAt: '2026-04-08T11:58:00.000Z',
+        now: new Date('2026-04-08T12:00:00.000Z'),
+      }),
+    ).toBe(false)
+  })
+})

--- a/lib/admin/__tests__/sessions.test.ts
+++ b/lib/admin/__tests__/sessions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest'
+
+import { getAdminSessionStatusFilterOptions, resolveAdminSessionStatusFilter } from '@/lib/admin/sessions'
+
+describe('resolveAdminSessionStatusFilter', () => {
+  test('expands grouped no-show filters into both no-show statuses', () => {
+    expect(resolveAdminSessionStatusFilter('no_show')).toEqual(['no_show_student', 'no_show_tutor'])
+  })
+
+  test('passes through concrete session statuses', () => {
+    expect(resolveAdminSessionStatusFilter('scheduled')).toEqual(['scheduled'])
+    expect(resolveAdminSessionStatusFilter('done')).toEqual(['done'])
+  })
+
+  test('drops invalid status filters', () => {
+    expect(resolveAdminSessionStatusFilter('bogus')).toEqual([])
+    expect(resolveAdminSessionStatusFilter('')).toEqual([])
+  })
+})
+
+describe('getAdminSessionStatusFilterOptions', () => {
+  test('includes a grouped no-show filter option for analytics deep links', () => {
+    expect(getAdminSessionStatusFilterOptions()).toContainEqual({
+      value: 'no_show',
+      label: 'No-show (all)',
+    })
+  })
+})

--- a/lib/admin/__tests__/users.test.ts
+++ b/lib/admin/__tests__/users.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildAdminUpdateUserProfileAuditEntry,
+  getHighestPriorityPaymentStatus,
+} from '@/lib/admin/users'
+
+describe('getHighestPriorityPaymentStatus', () => {
+  test('prefers paid over pending and rejected statuses', () => {
+    expect(getHighestPriorityPaymentStatus(['pending', 'rejected', 'paid'])).toBe('paid')
+  })
+
+  test('retains refunded when it is the only terminal status', () => {
+    expect(getHighestPriorityPaymentStatus(['refunded'])).toBe('refunded')
+  })
+})
+
+describe('buildAdminUpdateUserProfileAuditEntry', () => {
+  test('records the admin as the actor and the edited profile as the entity', () => {
+    expect(
+      buildAdminUpdateUserProfileAuditEntry({
+        actorUserId: 'admin-123',
+        targetUserId: 'student-456',
+        displayName: 'Updated Name',
+      }),
+    ).toEqual({
+      actor_user_id: 'admin-123',
+      action: 'admin_update_user_profile',
+      entity_type: 'user_profiles',
+      entity_id: 'student-456',
+      details: { display_name: 'Updated Name' },
+    })
+  })
+})

--- a/lib/admin/sessions.ts
+++ b/lib/admin/sessions.ts
@@ -1,0 +1,32 @@
+import type { Database } from '@/lib/supabase/database.types'
+
+type SessionStatus = Database['public']['Enums']['session_status_enum']
+
+export type AdminSessionStatusFilter = SessionStatus | 'no_show'
+
+const CONCRETE_SESSION_STATUSES = [
+  'scheduled',
+  'done',
+  'rescheduled',
+  'no_show_student',
+  'no_show_tutor',
+] as const satisfies SessionStatus[]
+
+export function resolveAdminSessionStatusFilter(raw: string | undefined): SessionStatus[] {
+  if (!raw) return []
+  if (raw === 'no_show') return ['no_show_student', 'no_show_tutor']
+
+  return CONCRETE_SESSION_STATUSES.includes(raw as SessionStatus) ? [raw as SessionStatus] : []
+}
+
+export function getAdminSessionStatusFilterOptions(): Array<{ value: string; label: string }> {
+  return [
+    { value: '', label: 'All statuses' },
+    { value: 'scheduled', label: 'Scheduled' },
+    { value: 'done', label: 'Done' },
+    { value: 'rescheduled', label: 'Rescheduled' },
+    { value: 'no_show', label: 'No-show (all)' },
+    { value: 'no_show_student', label: 'No-show (student)' },
+    { value: 'no_show_tutor', label: 'No-show (tutor)' },
+  ]
+}

--- a/lib/admin/users.ts
+++ b/lib/admin/users.ts
@@ -1,0 +1,58 @@
+import type { Database } from '@/lib/supabase/database.types'
+
+type PaymentStatus = Database['public']['Enums']['payment_status_enum']
+
+const PAYMENT_STATUS_PRIORITY: Record<PaymentStatus, number> = {
+  paid: 4,
+  pending: 3,
+  refunded: 2,
+  rejected: 1,
+}
+
+export function getHighestPriorityPaymentStatus(
+  statuses: ReadonlyArray<PaymentStatus | string | null | undefined>,
+): PaymentStatus | undefined {
+  let highest: PaymentStatus | undefined
+  let highestPriority = 0
+
+  for (const status of statuses) {
+    if (!status) continue
+
+    const priority = PAYMENT_STATUS_PRIORITY[status as PaymentStatus] ?? 0
+    if (priority > highestPriority) {
+      highest = status as PaymentStatus
+      highestPriority = priority
+    }
+  }
+
+  return highest
+}
+
+export function getAdminUserPaymentBadge(status: string): { label: string; cls: string } {
+  const map: Record<PaymentStatus, { label: string; cls: string }> = {
+    paid: { label: 'Paid', cls: 'bg-green-100 text-green-800 border border-green-300' },
+    pending: { label: 'Pending', cls: 'bg-yellow-100 text-yellow-800 border border-yellow-300' },
+    rejected: { label: 'Rejected', cls: 'bg-red-100 text-red-800 border border-red-300' },
+    refunded: { label: 'Refunded', cls: 'bg-slate-100 text-slate-700 border border-slate-300' },
+  }
+
+  return map[status as PaymentStatus] ?? { label: status, cls: 'bg-[#E0E0E0] text-[#121212]/60' }
+}
+
+export function buildAdminUpdateUserProfileAuditEntry({
+  actorUserId,
+  targetUserId,
+  displayName,
+}: {
+  actorUserId: string
+  targetUserId: string
+  displayName: string
+}) {
+  return {
+    actor_user_id: actorUserId,
+    action: 'admin_update_user_profile',
+    entity_type: 'user_profiles',
+    entity_id: targetUserId,
+    details: { display_name: displayName },
+  }
+}

--- a/lib/auth/utils.ts
+++ b/lib/auth/utils.ts
@@ -8,3 +8,61 @@ export function safeNext(raw: string | null): string {
   if (!raw.startsWith('/') || raw.startsWith('//')) return '/dashboard'
   return raw
 }
+
+export type AuthFlow = 'signup' | 'signin'
+export type OAuthAccountType = 'student' | 'parent'
+
+const FRESH_OAUTH_SIGNUP_WINDOW_MS = 10 * 60 * 1000
+
+export function buildAuthCallbackUrl(
+  origin: string,
+  options?: {
+    next?: string
+    flow?: AuthFlow
+    accountType?: OAuthAccountType
+  },
+): string {
+  const url = new URL('/auth/callback', origin)
+  const next = safeNext(options?.next ?? null)
+
+  if (next !== '/dashboard') {
+    url.searchParams.set('next', next)
+  }
+  if (options?.flow) {
+    url.searchParams.set('flow', options.flow)
+  }
+  if (options?.flow === 'signup' && options.accountType) {
+    url.searchParams.set('account_type', options.accountType)
+  }
+
+  return url.toString()
+}
+
+export function shouldPromoteOAuthParentSignup({
+  flow,
+  accountType,
+  primaryRole,
+  assignedRoles,
+  whatsappNumber,
+  profileCreatedAt,
+  now = new Date(),
+}: {
+  flow: string | null
+  accountType: string | null
+  primaryRole: string | null
+  assignedRoles: string[]
+  whatsappNumber: string | null
+  profileCreatedAt: string | null
+  now?: Date
+}): boolean {
+  if (flow !== 'signup' || accountType !== 'parent') return false
+  if (primaryRole !== 'student') return false
+  if (whatsappNumber) return false
+  if (assignedRoles.length !== 1 || assignedRoles[0] !== 'student') return false
+  if (!profileCreatedAt) return false
+
+  const createdAtMs = new Date(profileCreatedAt).getTime()
+  if (Number.isNaN(createdAtMs)) return false
+
+  return now.getTime() - createdAtMs <= FRESH_OAUTH_SIGNUP_WINDOW_MS
+}

--- a/lib/services/__tests__/session-status-transitions.test.ts
+++ b/lib/services/__tests__/session-status-transitions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
   getSessionUsageAdjustment,
+  isSessionRescheduleAllowed,
   isSessionCompletionAllowed,
 } from '@/lib/services/session-status-transitions'
 
@@ -40,6 +41,30 @@ describe('isSessionCompletionAllowed', () => {
     expect(
       isSessionCompletionAllowed({
         scheduledStartUtc: '2026-04-08T12:00:00.000Z',
+        now,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('isSessionRescheduleAllowed', () => {
+  test('blocks reschedules with less than 24 hours notice', () => {
+    const now = new Date('2026-04-08T12:00:00.000Z')
+
+    expect(
+      isSessionRescheduleAllowed({
+        scheduledStartUtc: '2026-04-09T11:59:00.000Z',
+        now,
+      }),
+    ).toBe(false)
+  })
+
+  test('allows reschedules with at least 24 hours notice', () => {
+    const now = new Date('2026-04-08T12:00:00.000Z')
+
+    expect(
+      isSessionRescheduleAllowed({
+        scheduledStartUtc: '2026-04-09T12:00:00.000Z',
         now,
       }),
     ).toBe(true)

--- a/lib/services/session-status-transitions.ts
+++ b/lib/services/session-status-transitions.ts
@@ -29,3 +29,18 @@ export function isSessionCompletionAllowed({
 }): boolean {
   return new Date(scheduledStartUtc).getTime() <= now.getTime()
 }
+
+export function isSessionRescheduleAllowed({
+  scheduledStartUtc,
+  now = new Date(),
+  minimumNoticeHours = 24,
+}: {
+  scheduledStartUtc: string
+  now?: Date
+  minimumNoticeHours?: number
+}): boolean {
+  const scheduledStartMs = new Date(scheduledStartUtc).getTime()
+  if (Number.isNaN(scheduledStartMs)) return false
+
+  return scheduledStartMs - now.getTime() >= minimumNoticeHours * 60 * 60 * 1000
+}

--- a/lib/services/sessions.ts
+++ b/lib/services/sessions.ts
@@ -9,6 +9,7 @@ import { generateSessions as generateSessionSlots, SchedulePattern } from "@/lib
 import {
   getSessionUsageAdjustment,
   isSessionCompletionAllowed,
+  isSessionRescheduleAllowed,
 } from "@/lib/services/session-status-transitions";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
 import { revalidatePath } from "next/cache";
@@ -398,9 +399,21 @@ export async function rescheduleSession({
     const adminUserId = await requireAdmin();
     const admin = createAdminClient();
 
+    const { data: currentSession, error: currentSessionErr } = await admin
+      .from("sessions")
+      .select("scheduled_start_utc")
+      .eq("id", sessionId)
+      .single();
+    if (currentSessionErr || !currentSession) {
+      throw new Error("Session not found.");
+    }
+
     // Prevent rescheduling to a past datetime
     if (new Date(newStartUtc) < new Date()) {
       throw new Error("Cannot reschedule a session to a past date and time.");
+    }
+    if (!isSessionRescheduleAllowed({ scheduledStartUtc: currentSession.scheduled_start_utc })) {
+      throw new Error("Sessions can only be rescheduled with at least 24 hours notice.");
     }
 
     const { error: updateErr } = await admin

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3056,28 +3056,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
@@ -4730,9 +4708,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3056,6 +3056,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",


### PR DESCRIPTION
## Summary
- harden launch-readiness flows for parent auth intent, verify-email resend, admin session/payment summaries, late reschedule enforcement, and parent-facing dashboard copy
- improve admin tutor assignment UX with accessible form controls and redirect successful assignments directly to match detail
- add durable seeded Playwright lifecycle coverage for request, payment, matching, session generation, and tutor completion against local Supabase

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build:local`
- `npm run test:e2e:local`