### PR TITLE
[codex] address launch issue batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Out of scope for MVP
 ├── app/                          # Next.js App Router routes (UI)
 ├── components/                   # UI components
 ├── lib/                          # Supabase clients, services, validators
-├── middleware.ts                 # Next.js edge middleware: session refresh + route protection
+├── proxy.ts                      # Next.js edge proxy: session refresh + route protection
 ├── supabase/                     # Migrations, seed data, local Supabase config
 ├── docs/                         # Product + ops + architecture docs
 │   ├── MVP.md
@@ -130,6 +130,7 @@ Open [http://localhost:3000](http://localhost:3000). You'll see the CorvEd landi
 | WhatsApp CTA button | ✅ `wa.me` deep link with prefilled message (requires `NEXT_PUBLIC_WHATSAPP_NUMBER` env var) |
 | `POST /api/leads` route | ✅ Server-side validation + Supabase insert via admin client |
 | `leads` DB migration | ✅ `supabase/migrations/20260223000001_create_leads_table.sql` — RLS: anon insert allowed, auth read/update |
+| **Admin: lead queue** | ✅ `app/admin/leads/page.tsx` — review Phase 0 intake records, open WhatsApp, update status, and store private admin notes |
 | Supabase clients wired up | ✅ `lib/supabase/client.ts`, `server.ts`, `admin.ts` |
 | **Auth: sign up (email/password)** | ✅ `app/auth/sign-up/page.tsx` — display name, email, password, timezone; min 8-char password |
 | **Auth: email verification** | ✅ `app/auth/verify/page.tsx` — instructions page; unverified users cannot reach dashboard |
@@ -138,7 +139,7 @@ Open [http://localhost:3000](http://localhost:3000). You'll see the CorvEd landi
 | **Auth: callback handler** | ✅ `app/auth/callback/route.ts` — PKCE code exchange; redirects to profile-setup if profile incomplete |
 | **Auth: profile setup** | ✅ `app/auth/profile-setup/page.tsx` — display name, WhatsApp number (auto-normalized), timezone (auto-detected) |
 | **Auth: sign out** | ✅ `app/auth/sign-out/route.ts` — POST clears session, redirects to sign-in |
-| **Route protection (middleware)** | ✅ `middleware.ts` — unauthenticated → sign-in for `/dashboard`, `/tutor`, `/admin`; authenticated → dashboard for auth pages |
+| **Route protection (proxy)** | ✅ `proxy.ts` — unauthenticated → sign-in for `/dashboard`, `/tutor`, `/admin`; authenticated → dashboard for auth pages |
 | **Role-aware dashboard redirect** | ✅ `app/dashboard/page.tsx` — admin→`/admin`, tutor→`/tutor`, student/parent stays on dashboard |
 | **Admin route protection** | ✅ `app/admin/layout.tsx` — verifies `admin` role server-side; non-admins → `/dashboard` |
 | **Tutor route protection** | ✅ `app/tutor/layout.tsx` — verifies `tutor` or `admin` role; others → `/dashboard` |
@@ -205,9 +206,9 @@ Open [http://localhost:3000](http://localhost:3000). You'll see the CorvEd landi
 | Admin: WhatsApp link on request detail (E11) | ✅ `/admin/requests/[id]` — "Open chat" link next to student's WhatsApp number |
 | Admin: WhatsApp link on tutor detail (E11) | ✅ `/admin/tutors/[id]` — "Open chat" link next to tutor's WhatsApp number |
 | **Policies page (E12 T12.1)** | ✅ `app/policies/page.tsx` — public page at `/policies`; covers reschedule (24h cutoff, exceptions), no-show (student/tutor/late-join), refund/expiry (no carryover, admin discretion), package terms (per subject, 60 min, assigned tutor), privacy; linked from landing page footer |
-| **Tutor code of conduct (E12 T12.2)** | ✅ `app/tutor/conduct/page.tsx` — public page at `/tutor/conduct`; covers punctuality, session quality, communication, privacy, quality expectations, incidents; acknowledgement checkbox added to tutor profile/application form (required before submit) |
-| **Admin: audit log (E12 T12.3)** | ✅ `app/admin/audit/page.tsx` — admin-only; shows recent 200 audit events newest-first; human-readable action labels; actor name, entity type/ID (truncated), details; uses `audit_logs` table (created in E5 migration) |
-| **Admin: analytics dashboard (E12 T12.4)** | ✅ `app/admin/analytics/page.tsx` — admin-only; 7 metric cards: active students, active tutors, upcoming sessions (next 7d), missed sessions (last 7d), unmarked sessions (needs follow-up), pending payments, pending tutor approvals; attention metrics highlighted in amber/orange; clickable cards link to relevant admin pages |
+| **Tutor code of conduct (E12 T12.2)** | ✅ `app/tutor/conduct/page.tsx` — public page at `/tutor/conduct`; acknowledgement is required on initial tutor signup and again in profile completion |
+| **Admin: audit log (E12 T12.3)** | ✅ `app/admin/audit/page.tsx` — admin-only; audit detail writes use `sanitizeAuditDetails()` so notes, Meet links, payment references, WhatsApp/contact fields, and names are redacted before storage |
+| **Admin: analytics dashboard (E12 T12.4)** | ✅ `app/admin/analytics/page.tsx` — admin-only; tracks active students/tutors, upcoming/missed/unmarked sessions, pending payments, pending tutors, and new lead intake follow-up |
 
 | Area | Status |
 |---|---|
@@ -216,6 +217,7 @@ Open [http://localhost:3000](http://localhost:3000). You'll see the CorvEd landi
 | WhatsApp CTA button | ✅ `wa.me` deep link with prefilled message (requires `NEXT_PUBLIC_WHATSAPP_NUMBER` env var) |
 | `POST /api/leads` route | ✅ Server-side validation + Supabase insert via admin client |
 | `leads` DB migration | ✅ `supabase/migrations/20260223000001_create_leads_table.sql` — RLS: anon insert allowed, auth read/update |
+| **Admin: lead queue** | ✅ `app/admin/leads/page.tsx` — review Phase 0 intake records, open WhatsApp, update status, and store private admin notes |
 | Supabase clients wired up | ✅ `lib/supabase/client.ts`, `server.ts`, `admin.ts` |
 | **Auth: sign up (email/password)** | ✅ `app/auth/sign-up/page.tsx` — display name, email, password, timezone; min 8-char password |
 | **Auth: email verification** | ✅ `app/auth/verify/page.tsx` — instructions page; unverified users cannot reach dashboard |
@@ -224,7 +226,7 @@ Open [http://localhost:3000](http://localhost:3000). You'll see the CorvEd landi
 | **Auth: callback handler** | ✅ `app/auth/callback/route.ts` — PKCE code exchange; redirects to profile-setup if profile incomplete |
 | **Auth: profile setup** | ✅ `app/auth/profile-setup/page.tsx` — display name, WhatsApp number (auto-normalized), timezone (auto-detected) |
 | **Auth: sign out** | ✅ `app/auth/sign-out/route.ts` — POST clears session, redirects to sign-in |
-| **Route protection (middleware)** | ✅ `middleware.ts` — unauthenticated → sign-in for `/dashboard`, `/tutor`, `/admin`; authenticated → dashboard for auth pages |
+| **Route protection (proxy)** | ✅ `proxy.ts` — unauthenticated → sign-in for `/dashboard`, `/tutor`, `/admin`; authenticated → dashboard for auth pages |
 | **Role-aware dashboard redirect** | ✅ `app/dashboard/page.tsx` — admin→`/admin`, tutor→`/tutor`, student/parent stays on dashboard |
 | **Admin route protection** | ✅ `app/admin/layout.tsx` — verifies `admin` role server-side; non-admins → `/dashboard` |
 | **Tutor route protection** | ✅ `app/tutor/layout.tsx` — verifies `tutor` or `admin` role; others → `/dashboard` |
@@ -341,6 +343,7 @@ Recommended workflow
 | `20260225000001_create_matches_table.sql` | `matches` table with unique `request_id` FK, `tutor_user_id`, `status` enum (matched/active/paused/ended), `meet_link`, `schedule_pattern` JSONB, `assigned_by_user_id`/`assigned_at`; updated_at trigger; RLS: admin full access, tutor and request creator can select. |
 | `20260225000002_create_sessions_table.sql` | `sessions` table (match_id FK, scheduled_start/end_utc, status enum, tutor_notes, updated_by_user_id); indexes on (match_id, start_utc) and (status, start_utc); 4 RLS policies (admin all, tutor select, student select via match→request, tutor update own); `increment_sessions_used(p_request_id)` RPC for atomic sessions_used increment; `tutor_update_session(p_session_id, p_status, p_notes)` security-definer RPC. |
 | `20260225000003_increment_sessions_used_guard.sql` | Adds `sessions_used < sessions_total` safety guard to `increment_sessions_used` RPC — prevents `sessions_used` from exceeding `sessions_total` (over-incrementing); sets safe `search_path`; restricts `EXECUTE` to `service_role` only. |
+| `20260426000001_sanitize_session_audit_details.sql` | Replaces `tutor_update_session` so audit details keep status transitions but redact tutor notes from `audit_logs.details`. |
 
 > **Supabase Dashboard settings required for auth** (after running migrations):
 >

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -99,7 +99,7 @@ const updateProfileSchema = z.object({
 
 /** Update a user's display name and WhatsApp number. */
 export async function updateUserProfile(userId: string, formData: FormData) {
-  await requireAdmin();
+  const adminUserId = await requireAdmin();
 
   const raw = {
     display_name: formData.get("display_name") as string,
@@ -124,7 +124,7 @@ export async function updateUserProfile(userId: string, formData: FormData) {
 
   await admin.from("audit_logs").insert([
     {
-      actor_user_id: userId,
+      actor_user_id: adminUserId,
       action: "admin_update_user_profile",
       entity_type: "user_profiles",
       entity_id: userId,

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -7,7 +7,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { buildAdminUpdateUserProfileAuditEntry } from "@/lib/admin/users";
+import { sanitizeAuditDetails } from "@/lib/audit/sanitize";
 
 const VALID_ROLES = ["student", "parent", "tutor", "admin"] as const;
 type Role = (typeof VALID_ROLES)[number];
@@ -99,7 +99,7 @@ const updateProfileSchema = z.object({
 
 /** Update a user's display name and WhatsApp number. */
 export async function updateUserProfile(userId: string, formData: FormData) {
-  const adminUserId = await requireAdmin();
+  await requireAdmin();
 
   const raw = {
     display_name: formData.get("display_name") as string,
@@ -123,11 +123,13 @@ export async function updateUserProfile(userId: string, formData: FormData) {
   if (error) throw new Error(`Failed to update profile: ${error.message}`);
 
   await admin.from("audit_logs").insert([
-    buildAdminUpdateUserProfileAuditEntry({
-      actorUserId: adminUserId,
-      targetUserId: userId,
-      displayName: parsed.data.display_name,
-    }),
+    {
+      actor_user_id: userId,
+      action: "admin_update_user_profile",
+      entity_type: "user_profiles",
+      entity_id: userId,
+      details: sanitizeAuditDetails({ display_name: parsed.data.display_name }),
+    },
   ]);
 
   revalidatePath("/admin/users");

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -57,6 +57,7 @@ export default async function AdminAnalyticsPage() {
     unmarkedSessions,
     pendingPayments,
     pendingTutors,
+    newLeads,
   ] = await Promise.all([
     // Active students: unique users with active requests
     admin.from('requests').select('created_by_user_id').eq('status', 'active'),
@@ -92,6 +93,8 @@ export default async function AdminAnalyticsPage() {
       .from('tutor_profiles')
       .select('tutor_user_id', { count: 'exact', head: true })
       .eq('approved', false),
+    // Lead intake records waiting for first follow-up
+    admin.from('leads').select('id', { count: 'exact', head: true }).eq('status', 'new'),
   ])
 
   const firstError =
@@ -101,7 +104,8 @@ export default async function AdminAnalyticsPage() {
     missedSessions.error ||
     unmarkedSessions.error ||
     pendingPayments.error ||
-    pendingTutors.error
+    pendingTutors.error ||
+    newLeads.error
 
   if (firstError) {
     throw new Error(`Failed to load analytics metrics: ${firstError.message}`)
@@ -117,6 +121,7 @@ export default async function AdminAnalyticsPage() {
     unmarkedSessions: unmarkedSessions.count ?? 0,
     pendingPayments: pendingPayments.count ?? 0,
     pendingTutors: pendingTutors.count ?? 0,
+    newLeads: newLeads.count ?? 0,
   }
 
   return (
@@ -238,6 +243,15 @@ export default async function AdminAnalyticsPage() {
             variant={metrics.pendingTutors > 0 ? 'attention' : 'normal'}
             href="/admin/tutors"
             linkLabel="Review tutors →"
+          />
+          <MetricCard
+            label="New Leads"
+            value={metrics.newLeads}
+            unit="awaiting follow-up"
+            icon="☎"
+            variant={metrics.newLeads > 0 ? 'attention' : 'normal'}
+            href="/admin/leads?status=new"
+            linkLabel="Review leads →"
           />
         </div>
       </section>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -33,6 +33,7 @@ export default async function AdminLayout({
 
   const navLinks = [
     { href: '/admin', label: 'Dashboard' },
+    { href: '/admin/leads', label: 'Leads' },
     { href: '/admin/users', label: 'Users' },
     { href: '/admin/requests', label: 'Requests' },
     { href: '/admin/payments', label: 'Payments' },

--- a/app/admin/leads/actions.ts
+++ b/app/admin/leads/actions.ts
@@ -40,7 +40,7 @@ export async function updateLeadStatus(formData: FormData) {
 
   if (error) throw new Error(`Failed to update lead: ${error.message}`)
 
-  await admin.from('audit_logs').insert([
+  const { error: auditError } = await admin.from('audit_logs').insert([
     {
       actor_user_id: adminUserId,
       action: 'lead_status_updated',
@@ -53,6 +53,7 @@ export async function updateLeadStatus(formData: FormData) {
       }),
     },
   ])
+  if (auditError) throw new Error(`Failed to write audit log: ${auditError.message}`)
 
   revalidatePath('/admin')
   revalidatePath('/admin/analytics')

--- a/app/admin/leads/actions.ts
+++ b/app/admin/leads/actions.ts
@@ -1,0 +1,60 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { requireAdmin } from '@/lib/auth/requireAdmin'
+import { sanitizeAuditDetails } from '@/lib/audit/sanitize'
+import { leadStatusUpdateSchema } from '@/lib/validators/lead-admin'
+
+export async function updateLeadStatus(formData: FormData) {
+  const adminUserId = await requireAdmin()
+  const parsed = leadStatusUpdateSchema.safeParse({
+    leadId: formData.get('leadId'),
+    status: formData.get('status'),
+    admin_notes: formData.get('admin_notes') ?? '',
+  })
+
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues.map((issue) => issue.message).join(', '))
+  }
+
+  const admin = createAdminClient()
+  const { leadId, status, admin_notes } = parsed.data
+
+  const { data: previousLead, error: fetchError } = await admin
+    .from('leads')
+    .select('id, status')
+    .eq('id', leadId)
+    .maybeSingle()
+
+  if (fetchError) throw new Error(`Failed to load lead: ${fetchError.message}`)
+  if (!previousLead) throw new Error('Lead not found.')
+
+  const { error } = await admin
+    .from('leads')
+    .update({
+      status,
+      admin_notes: admin_notes?.trim() ? admin_notes.trim() : null,
+    })
+    .eq('id', leadId)
+
+  if (error) throw new Error(`Failed to update lead: ${error.message}`)
+
+  await admin.from('audit_logs').insert([
+    {
+      actor_user_id: adminUserId,
+      action: 'lead_status_updated',
+      entity_type: 'lead',
+      entity_id: leadId,
+      details: sanitizeAuditDetails({
+        previous_status: previousLead.status,
+        status,
+        admin_notes,
+      }),
+    },
+  ])
+
+  revalidatePath('/admin')
+  revalidatePath('/admin/analytics')
+  revalidatePath('/admin/leads')
+}

--- a/app/admin/leads/page.tsx
+++ b/app/admin/leads/page.tsx
@@ -1,0 +1,213 @@
+export const dynamic = 'force-dynamic'
+
+import Link from 'next/link'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { WhatsAppLink } from '@/components/WhatsAppLink'
+import { leadStatusValues } from '@/lib/validators/lead-admin'
+import { updateLeadStatus } from './actions'
+
+type LeadStatus = (typeof leadStatusValues)[number]
+
+type LeadRow = {
+  id: string
+  full_name: string
+  whatsapp_number: string
+  role: string
+  child_name: string | null
+  level: string
+  subject: string
+  exam_board: string
+  availability: string
+  city_timezone: string
+  goals: string | null
+  preferred_package: string | null
+  status: LeadStatus
+  admin_notes: string | null
+  created_at: string
+}
+
+const STATUS_LABELS: Record<LeadStatus, string> = {
+  new: 'New',
+  contacted: 'Contacted',
+  qualified: 'Qualified',
+  disqualified: 'Disqualified',
+}
+
+const SUBJECT_LABELS: Record<string, string> = {
+  math: 'Math',
+  physics: 'Physics',
+  chemistry: 'Chemistry',
+  biology: 'Biology',
+  english: 'English',
+  cs: 'Computer Science',
+  pak_studies: 'Pakistan Studies',
+  islamiyat: 'Islamiyat',
+  urdu: 'Urdu',
+}
+
+function formatLeadDate(value: string) {
+  return new Date(value).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+function buildStatusHref(status: LeadStatus | 'all') {
+  return status === 'all' ? '/admin/leads' : `/admin/leads?status=${status}`
+}
+
+export default async function AdminLeadsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>
+}) {
+  const params = await searchParams
+  const activeStatus = leadStatusValues.includes(params.status as LeadStatus)
+    ? (params.status as LeadStatus)
+    : 'all'
+
+  const admin = createAdminClient()
+  let query = admin
+    .from('leads')
+    .select(
+      'id, full_name, whatsapp_number, role, child_name, level, subject, exam_board, availability, city_timezone, goals, preferred_package, status, admin_notes, created_at',
+    )
+    .order('created_at', { ascending: false })
+    .limit(100)
+
+  if (activeStatus !== 'all') {
+    query = query.eq('status', activeStatus)
+  }
+
+  const { data, error } = await query
+  if (error) throw new Error(`Failed to load leads: ${error.message}`)
+
+  const leads = (data ?? []) as LeadRow[]
+  const statusLinks: (LeadStatus | 'all')[] = ['all', ...leadStatusValues]
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-3xl font-black uppercase tracking-tighter text-[#121212]">Leads</h1>
+          <p className="mt-1 text-sm text-[#121212]/60">
+            Phase 0 intake records for manual WhatsApp follow-up.
+          </p>
+        </div>
+        <p className="text-sm text-[#121212]/60">
+          {leads.length} lead{leads.length !== 1 ? 's' : ''}
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        {statusLinks.map((status) => {
+          const isActive = activeStatus === status
+          return (
+            <Link
+              key={status}
+              href={buildStatusHref(status)}
+              className={`px-3 py-1.5 text-sm font-medium transition ${
+                isActive
+                  ? 'bg-[#1040C0] text-white'
+                  : 'bg-white text-[#121212]/70 hover:bg-[#E0E0E0]'
+              }`}
+            >
+              {status === 'all' ? 'All' : STATUS_LABELS[status]}
+            </Link>
+          )
+        })}
+      </div>
+
+      {leads.length === 0 ? (
+        <div className="border-4 border-[#121212] bg-white px-8 py-12 text-center">
+          <p className="text-[#121212]/60">No leads found for this filter.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {leads.map((lead) => (
+            <article key={lead.id} className="border-4 border-[#121212] bg-white p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="text-lg font-black uppercase tracking-tight text-[#121212]">
+                      {lead.full_name}
+                    </h2>
+                    <span className="border-2 border-[#121212] px-2 py-0.5 text-[11px] font-bold uppercase tracking-wider text-[#121212]">
+                      {STATUS_LABELS[lead.status]}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-[#121212]/50">
+                    {formatLeadDate(lead.created_at)} · {lead.role}
+                    {lead.child_name ? ` for ${lead.child_name}` : ''} · {lead.city_timezone}
+                  </p>
+                </div>
+                <WhatsAppLink number={lead.whatsapp_number} label="Open WhatsApp" />
+              </div>
+
+              <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                <div>
+                  <dt className="text-[10px] font-black uppercase tracking-widest text-[#121212]/40">Subject</dt>
+                  <dd className="mt-1 text-[#121212]">{SUBJECT_LABELS[lead.subject] ?? lead.subject}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] font-black uppercase tracking-widest text-[#121212]/40">Level</dt>
+                  <dd className="mt-1 text-[#121212]">{lead.level === 'o_levels' ? 'O Levels' : 'A Levels'}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] font-black uppercase tracking-widest text-[#121212]/40">Exam Board</dt>
+                  <dd className="mt-1 text-[#121212]">{lead.exam_board.replace(/_/g, ' ')}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] font-black uppercase tracking-widest text-[#121212]/40">Package</dt>
+                  <dd className="mt-1 text-[#121212]">{lead.preferred_package ? `${lead.preferred_package} sessions` : 'Not sure'}</dd>
+                </div>
+              </dl>
+
+              <div className="mt-4 grid gap-3 text-sm lg:grid-cols-2">
+                <div>
+                  <p className="text-[10px] font-black uppercase tracking-widest text-[#121212]/40">Availability</p>
+                  <p className="mt-1 whitespace-pre-wrap text-[#121212]/70">{lead.availability}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-black uppercase tracking-widest text-[#121212]/40">Goals</p>
+                  <p className="mt-1 whitespace-pre-wrap text-[#121212]/70">{lead.goals || 'No goals provided.'}</p>
+                </div>
+              </div>
+
+              <form action={updateLeadStatus} className="mt-4 grid gap-3 border-t-2 border-[#E0E0E0] pt-4 md:grid-cols-[180px_1fr_auto]">
+                <input type="hidden" name="leadId" value={lead.id} />
+                <select
+                  name="status"
+                  defaultValue={lead.status}
+                  className="border-2 border-[#121212] px-3 py-2 text-sm"
+                  aria-label={`Status for ${lead.full_name}`}
+                >
+                  {leadStatusValues.map((status) => (
+                    <option key={status} value={status}>
+                      {STATUS_LABELS[status]}
+                    </option>
+                  ))}
+                </select>
+                <textarea
+                  name="admin_notes"
+                  defaultValue={lead.admin_notes ?? ''}
+                  rows={2}
+                  maxLength={1000}
+                  placeholder="Private admin notes"
+                  className="border-2 border-[#B0B0B0] px-3 py-2 text-sm outline-none focus:border-[#1040C0] focus:ring-1 focus:ring-[#1040C0]"
+                />
+                <button
+                  type="submit"
+                  className="border-2 border-[#121212] bg-[#121212] px-4 py-2 text-xs font-bold uppercase tracking-widest text-white hover:bg-[#333]"
+                >
+                  Save
+                </button>
+              </form>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -10,7 +10,8 @@ export default async function AdminPage() {
   const admin = createAdminClient()
   const nowIso = new Date().toISOString()
 
-  const [pendingPayments, pendingTutors, newRequests, upcomingSessions, activeSubjects] = await Promise.all([
+  const [newLeads, pendingPayments, pendingTutors, newRequests, upcomingSessions, activeSubjects] = await Promise.all([
+    admin.from('leads').select('id', { count: 'exact', head: true }).eq('status', 'new'),
     admin.from('payments').select('id', { count: 'exact', head: true }).eq('status', 'pending'),
     admin.from('tutor_profiles').select('tutor_user_id', { count: 'exact', head: true }).eq('approved', false),
     admin.from('requests').select('id', { count: 'exact', head: true }).eq('status', 'new'),
@@ -19,6 +20,7 @@ export default async function AdminPage() {
   ])
 
   const counts: Record<string, { count: number; countLabel: string }> = {
+    '/admin/leads': { count: newLeads.count ?? 0, countLabel: 'new' },
     '/admin/payments': { count: pendingPayments.count ?? 0, countLabel: 'pending' },
     '/admin/tutors': { count: pendingTutors.count ?? 0, countLabel: 'pending' },
     '/admin/requests': { count: newRequests.count ?? 0, countLabel: 'new' },
@@ -27,6 +29,7 @@ export default async function AdminPage() {
   }
 
   const CARDS = [
+    { href: '/admin/leads', title: 'Leads', desc: 'Review Phase 0 intake records and track WhatsApp follow-up.', accent: 'yellow' as const },
     { href: '/admin/users', title: 'User Management', desc: 'View all users, assign or remove roles, and set primary roles.', accent: 'blue' as const },
     { href: '/admin/requests', title: 'Requests', desc: 'Review and manage student tutoring requests.', accent: 'red' as const },
     { href: '/admin/payments', title: 'Payments', desc: 'Verify bank transfers and activate packages.', accent: 'yellow' as const },

--- a/app/admin/payments/actions.ts
+++ b/app/admin/payments/actions.ts
@@ -7,6 +7,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { requireAdmin } from '@/lib/auth/requireAdmin'
 import { revalidatePath } from 'next/cache'
 import { markPaidSchema, rejectPaymentSchema } from '@/lib/validators/payment'
+import { sanitizeAuditDetails } from '@/lib/audit/sanitize'
 
 export async function markPaymentPaid(
   paymentId: string,
@@ -86,7 +87,7 @@ export async function markPaymentPaid(
       action: 'payment_marked_paid',
       entity_type: 'payment',
       entity_id: paymentId,
-      details: { package_id: packageId, request_id: requestId },
+      details: sanitizeAuditDetails({ package_id: packageId, request_id: requestId }),
     },
   ])
   if (auditError) {
@@ -133,7 +134,7 @@ export async function markPaymentRejected(
       action: 'payment_marked_rejected',
       entity_type: 'payment',
       entity_id: paymentId,
-      details: { rejection_note: rejectionNote },
+      details: sanitizeAuditDetails({ rejection_note: rejectionNote }),
     },
   ])
   if (auditError) {

--- a/app/admin/requests/actions.ts
+++ b/app/admin/requests/actions.ts
@@ -6,9 +6,9 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { requireAdmin } from '@/lib/auth/requireAdmin'
 import { revalidatePath } from 'next/cache'
-import { redirect } from 'next/navigation'
 import type { Json } from '@/lib/supabase/database.types'
 import type { Database } from '@/lib/supabase/database.types'
+import { sanitizeAuditDetails } from '@/lib/audit/sanitize'
 
 /** Create a match record, advance request to 'matched', and write audit log. */
 export async function assignTutor({
@@ -27,8 +27,6 @@ export async function assignTutor({
     duration_mins: number
   }
 }): Promise<{ error?: string; matchId?: string }> {
-  let assignedMatchId: string | null = null
-
   try {
     const adminUserId = await requireAdmin()
     const admin = createAdminClient()
@@ -85,7 +83,7 @@ export async function assignTutor({
         action: 'tutor_assigned',
         entity_type: 'match',
         entity_id: match.id,
-        details: { tutor_user_id: tutorUserId, request_id: requestId },
+        details: sanitizeAuditDetails({ tutor_user_id: tutorUserId, request_id: requestId }),
       },
     ])
     if (auditError) {
@@ -95,13 +93,10 @@ export async function assignTutor({
     revalidatePath(`/admin/requests/${requestId}`)
     revalidatePath('/admin/requests')
     revalidatePath('/admin/matches')
-    revalidatePath(`/admin/matches/${match.id}`)
-    assignedMatchId = match.id
+    return { matchId: match.id }
   } catch (err) {
     return { error: err instanceof Error ? err.message : 'An unexpected error occurred.' }
   }
-
-  redirect(`/admin/matches/${assignedMatchId}?assigned=1`)
 }
 
 /** Update match.tutor_user_id to a new tutor and write audit log (history kept). */
@@ -146,11 +141,11 @@ export async function reassignTutor({
         action: 'tutor_reassigned',
         entity_type: 'match',
         entity_id: matchId,
-        details: {
+        details: sanitizeAuditDetails({
           old_tutor_user_id: previousTutorUserId,
           new_tutor_user_id: newTutorUserId,
           reason: reason || null,
-        },
+        }),
       },
     ])
     if (auditError) {
@@ -220,7 +215,7 @@ export async function updateMatchDetails({
         action: 'match_details_updated',
         entity_type: 'match',
         entity_id: matchId,
-        details: auditDetails as Json,
+        details: sanitizeAuditDetails(auditDetails) as Json,
       },
     ])
     if (auditError) {
@@ -258,7 +253,7 @@ export async function updateMatchNotes({
       action: 'match_notes_updated',
       entity_type: 'match',
       entity_id: matchId,
-      details: { admin_notes: adminNotes || null },
+      details: sanitizeAuditDetails({ admin_notes: adminNotes || null }),
     }])
 
     revalidatePath(`/admin/matches/${matchId}`)
@@ -326,7 +321,7 @@ export async function adminCancelRequest(
       action: 'admin_cancel_request',
       entity_type: 'request',
       entity_id: requestId,
-      details: { previous_status: previousStatus, reason: reason || null },
+      details: sanitizeAuditDetails({ previous_status: previousStatus, reason: reason || null }),
     }])
 
     revalidatePath(`/admin/requests/${requestId}`)
@@ -371,7 +366,7 @@ export async function adminUpdateRequestStatus(
       action: 'admin_update_request_status',
       entity_type: 'request',
       entity_id: requestId,
-      details: { previous_status: previousStatus, new_status: newStatus },
+      details: sanitizeAuditDetails({ previous_status: previousStatus, new_status: newStatus }),
     }])
 
     revalidatePath(`/admin/requests/${requestId}`)

--- a/app/admin/sessions/SessionFilters.tsx
+++ b/app/admin/sessions/SessionFilters.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useRef } from 'react'
-import { getAdminSessionStatusFilterOptions } from '@/lib/admin/sessions'
+import { SESSION_STATUS_FILTER_OPTIONS } from '@/lib/utils/session-filter'
 
 // ── Student-picker search bar ─────────────────────────────────────────────────
 
@@ -84,8 +84,6 @@ export function SessionViewControls({
     { value: 'past', label: 'Past', count: pastCount },
   ]
 
-  const statuses = getAdminSessionStatusFilterOptions()
-
   return (
     <div className="flex flex-wrap items-center justify-between gap-3">
       {/* Tabs */}
@@ -125,7 +123,7 @@ export function SessionViewControls({
         className="border-2 border-[#121212] px-3 py-1.5 text-sm"
         aria-label="Filter by status"
       >
-        {statuses.map((s) => (
+        {SESSION_STATUS_FILTER_OPTIONS.map((s) => (
           <option key={s.value} value={s.value}>
             {s.label}
           </option>

--- a/app/admin/sessions/page.tsx
+++ b/app/admin/sessions/page.tsx
@@ -202,7 +202,7 @@ export default async function AdminSessionsPage({
                       />
                     )}
                     <a
-                      href={`/admin/sessions?student=${student.userId}&child=${encodeURIComponent(student.forStudentName ?? '')}${filterStatus ? `&view=past&status=${encodeURIComponent(filterStatus)}` : ''}`}
+                      href={`/admin/sessions?student=${student.userId}&child=${encodeURIComponent(student.forStudentName ?? '')}${filterStatus ? `&status=${encodeURIComponent(filterStatus)}${['done', 'rescheduled', 'no_show', 'no_show_student', 'no_show_tutor'].includes(filterStatus) ? '&view=past' : ''}` : ''}`}
                       className="border-2 border-[#121212] px-3 py-1.5 text-xs font-bold uppercase tracking-widest text-[#121212] hover:bg-[#F0F0F0]"
                     >
                       View →

--- a/app/admin/sessions/page.tsx
+++ b/app/admin/sessions/page.tsx
@@ -14,6 +14,7 @@ import {
   getSessionStatusesForFilter,
   getSessionStatusFilterLabel,
   isSessionStatusFilter,
+  PAST_ONLY_SESSION_STATUS_FILTERS,
 } from '@/lib/utils/session-filter'
 import { SessionStatusForm, RescheduleForm } from './SessionActions'
 import { StudentSearchBar, SessionViewControls, type SessionView } from './SessionFilters'
@@ -202,7 +203,7 @@ export default async function AdminSessionsPage({
                       />
                     )}
                     <a
-                      href={`/admin/sessions?student=${student.userId}&child=${encodeURIComponent(student.forStudentName ?? '')}${filterStatus ? `&status=${encodeURIComponent(filterStatus)}${['done', 'rescheduled', 'no_show', 'no_show_student', 'no_show_tutor'].includes(filterStatus) ? '&view=past' : ''}` : ''}`}
+                      href={`/admin/sessions?student=${student.userId}&child=${encodeURIComponent(student.forStudentName ?? '')}${filterStatus ? `&status=${encodeURIComponent(filterStatus)}${(PAST_ONLY_SESSION_STATUS_FILTERS as string[]).includes(filterStatus) ? '&view=past' : ''}` : ''}`}
                       className="border-2 border-[#121212] px-3 py-1.5 text-xs font-bold uppercase tracking-widest text-[#121212] hover:bg-[#F0F0F0]"
                     >
                       View →

--- a/app/admin/sessions/page.tsx
+++ b/app/admin/sessions/page.tsx
@@ -10,13 +10,17 @@ import {
   formatSessionTime,
   type SessionStatus,
 } from '@/lib/utils/session'
+import {
+  getSessionStatusesForFilter,
+  getSessionStatusFilterLabel,
+  isSessionStatusFilter,
+} from '@/lib/utils/session-filter'
 import { SessionStatusForm, RescheduleForm } from './SessionActions'
 import { StudentSearchBar, SessionViewControls, type SessionView } from './SessionFilters'
 import Link from 'next/link'
 import { CopyMessageButton } from '@/components/CopyMessageButton'
 import { WhatsAppLink } from '@/components/WhatsAppLink'
 import { templates } from '@/lib/whatsapp/templates'
-import { resolveAdminSessionStatusFilter } from '@/lib/admin/sessions'
 
 const ADMIN_TIMEZONE = 'Asia/Karachi'
 const IMPOSSIBLE_ID = '00000000-0000-0000-0000-000000000000'
@@ -30,8 +34,7 @@ export default async function AdminSessionsPage({
   const studentId = params.student
   const childParam = params.child // undefined = no filter, '' = self-request, name = parent's child
   const view = (params.view === 'past' ? 'past' : 'upcoming') as SessionView
-  const filterStatus = params.status ?? ''
-  const resolvedStatusFilters = resolveAdminSessionStatusFilter(filterStatus)
+  const filterStatus = params.status && isSessionStatusFilter(params.status) ? params.status : ''
   const studentSearch = params.search ?? ''
 
   const admin = createAdminClient()
@@ -54,9 +57,11 @@ export default async function AdminSessionsPage({
       matchIds.length > 0
         ? await admin
             .from('sessions')
-            .select('match_id, scheduled_start_utc')
+            .select('match_id, scheduled_start_utc, status')
             .in('match_id', matchIds)
-        : { data: [] as { match_id: string; scheduled_start_utc: string }[] }
+        : { data: [] as { match_id: string; scheduled_start_utc: string; status: SessionStatus }[] }
+
+    const filteredStatuses = filterStatus ? getSessionStatusesForFilter(filterStatus) : []
 
     // Aggregate per student
     type StudentEntry = {
@@ -120,6 +125,15 @@ export default async function AdminSessionsPage({
 
     // Apply search filter and sort by most upcoming first
     let students = [...studentMap.values()]
+    if (filteredStatuses.length > 0) {
+      students = students.filter((student) =>
+        (sessionRows ?? []).some(
+          (session) =>
+            student.matchIds.includes(session.match_id) &&
+            filteredStatuses.includes(session.status as SessionStatus),
+        ),
+      )
+    }
     if (studentSearch) {
       const q = studentSearch.toLowerCase()
       students = students.filter((s) => s.displayName.toLowerCase().includes(q))
@@ -188,7 +202,7 @@ export default async function AdminSessionsPage({
                       />
                     )}
                     <a
-                      href={`/admin/sessions?student=${student.userId}&child=${encodeURIComponent(student.forStudentName ?? '')}`}
+                      href={`/admin/sessions?student=${student.userId}&child=${encodeURIComponent(student.forStudentName ?? '')}${filterStatus ? `&view=past&status=${encodeURIComponent(filterStatus)}` : ''}`}
                       className="border-2 border-[#121212] px-3 py-1.5 text-xs font-bold uppercase tracking-widest text-[#121212] hover:bg-[#F0F0F0]"
                     >
                       View →
@@ -293,10 +307,13 @@ export default async function AdminSessionsPage({
     .in('match_id', safeMatchIds)
     .order('scheduled_start_utc', { ascending: true })
 
-  if (resolvedStatusFilters.length === 1) {
-    sessionsQuery = sessionsQuery.eq('status', resolvedStatusFilters[0] as SessionStatus)
-  } else if (resolvedStatusFilters.length > 1) {
-    sessionsQuery = sessionsQuery.in('status', resolvedStatusFilters)
+  if (filterStatus) {
+    const statuses = getSessionStatusesForFilter(filterStatus)
+    if (statuses.length === 1) {
+      sessionsQuery = sessionsQuery.eq('status', statuses[0])
+    } else if (statuses.length > 1) {
+      sessionsQuery = sessionsQuery.in('status', statuses)
+    }
   }
 
   const { data: sessionsData } = await sessionsQuery
@@ -363,7 +380,7 @@ export default async function AdminSessionsPage({
         <div className="border-4 border-[#121212] bg-white px-8 py-10 text-center">
           <p className="text-sm text-[#121212]/50">
             No {view} sessions
-            {filterStatus ? ` with status "${filterStatus.replace(/_/g, ' ')}"` : ''}.
+            {filterStatus ? ` with status "${getSessionStatusFilterLabel(filterStatus)}"` : ''}.
           </p>
         </div>
       ) : (

--- a/app/admin/tutors/actions.ts
+++ b/app/admin/tutors/actions.ts
@@ -6,6 +6,7 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { requireAdmin } from '@/lib/auth/requireAdmin'
 import { revalidatePath } from 'next/cache'
+import { sanitizeAuditDetails } from '@/lib/audit/sanitize'
 
 /** Set tutor_profiles.approved = true and write audit log. */
 export async function approveTutor(tutorUserId: string): Promise<{ error?: string }> {
@@ -26,7 +27,7 @@ export async function approveTutor(tutorUserId: string): Promise<{ error?: strin
         action: 'tutor_approved',
         entity_type: 'tutor_profile',
         entity_id: tutorUserId,
-        details: {},
+        details: sanitizeAuditDetails({}),
       },
     ])
     if (auditError) {
@@ -59,7 +60,7 @@ export async function revokeTutorApproval(tutorUserId: string): Promise<{ error?
         action: 'tutor_approval_revoked',
         entity_type: 'tutor_profile',
         entity_id: tutorUserId,
-        details: {},
+        details: sanitizeAuditDetails({}),
       },
     ])
     if (auditError) {

--- a/app/auth/sign-up/tutor/page.tsx
+++ b/app/auth/sign-up/tutor/page.tsx
@@ -7,10 +7,10 @@
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
+import { tutorSignUpSchema, type TutorSignUpData } from '@/lib/validators/tutor-sign-up'
 import {
   BauhausLogo,
   BauhausLabel,
@@ -19,33 +19,8 @@ import {
   BauhausFieldError,
   BauhausServerError,
   BauhausButton,
-  BauhausDivider,
   BauhausGeometricPanel,
 } from '@/components/ui/bauhaus'
-
-const tutorSignUpSchema = z
-  .object({
-    display_name: z.string().min(2, 'Name must be at least 2 characters'),
-    email: z.string().email('Enter a valid email address'),
-    password: z.string().min(8, 'Password must be at least 8 characters'),
-    confirm_password: z.string().min(1, 'Please confirm your password'),
-    timezone: z.string().min(1, 'Please select a timezone'),
-    bio: z
-      .string()
-      .min(30, 'Please write at least 30 characters about yourself')
-      .max(600, 'Keep bio under 600 characters'),
-    experience_years: z
-      .string()
-      .min(1, 'Please select your experience level'),
-    education: z.string().min(3, 'Please enter your highest qualification'),
-    teaching_approach: z.string().optional(),
-  })
-  .refine((d) => d.password === d.confirm_password, {
-    message: 'Passwords do not match',
-    path: ['confirm_password'],
-  })
-
-type TutorSignUpData = z.infer<typeof tutorSignUpSchema>
 
 const TIMEZONES = [
   { value: 'Asia/Karachi', label: 'Asia/Karachi (PKT, UTC+5)' },
@@ -84,7 +59,7 @@ export default function TutorSignUpPage() {
     formState: { errors, isSubmitting },
   } = useForm<TutorSignUpData>({
     resolver: zodResolver(tutorSignUpSchema),
-    defaultValues: { timezone: 'Asia/Karachi' },
+    defaultValues: { timezone: 'Asia/Karachi', conductAcknowledged: false },
   })
 
   const bio = watch('bio') ?? ''
@@ -332,6 +307,35 @@ export default function TutorSignUpPage() {
                     />
                   </div>
                 </>
+              ))}
+
+              {/* Step 3: Conduct acknowledgement */}
+              {section(3, 'Tutor Conduct', (
+                <div>
+                  <label
+                    htmlFor="t-conduct"
+                    className="flex cursor-pointer items-start gap-3 text-sm leading-relaxed text-[#121212]/70"
+                  >
+                    <input
+                      id="t-conduct"
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 shrink-0 border-2 border-[#121212] accent-[#1040C0]"
+                      aria-invalid={errors.conductAcknowledged ? 'true' : 'false'}
+                      {...register('conductAcknowledged')}
+                    />
+                    <span>
+                      I have read and agree to the{' '}
+                      <Link
+                        href="/tutor/conduct"
+                        className="font-bold text-[#1040C0] underline underline-offset-2 hover:text-[#D02020]"
+                      >
+                        CorvEd Tutor Code of Conduct
+                      </Link>
+                      .
+                    </span>
+                  </label>
+                  <BauhausFieldError message={errors.conductAcknowledged?.message} />
+                </div>
               ))}
 
               {/* What happens next */}

--- a/app/dashboard/requests/actions.ts
+++ b/app/dashboard/requests/actions.ts
@@ -5,6 +5,7 @@ import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { revalidatePath } from 'next/cache'
 import type { Database } from '@/lib/supabase/database.types'
+import { sanitizeAuditDetails } from '@/lib/audit/sanitize'
 
 /**
  * Student can cancel their own request if it hasn't been paid for.
@@ -81,7 +82,7 @@ export async function cancelRequest(requestId: string): Promise<{ error?: string
       action: 'cancel_request',
       entity_type: 'request',
       entity_id: requestId,
-      details: { cancelled_by: 'student', previous_status: request.status },
+      details: sanitizeAuditDetails({ cancelled_by: 'student', previous_status: request.status }),
     },
   ])
 

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -98,7 +98,7 @@
 | | |
 |---|---|
 | **Severity** | Critical |
-| **Status** | **RESOLVED** — `middleware.ts` now checks email verification status (redirects unverified to `/auth/verify`) and enforces role-based routing (`/admin/*` → admin only, `/tutor/*` → tutor/admin only). |
+| **Status** | **RESOLVED** — `proxy.ts` now checks email verification status (redirects unverified to `/auth/verify`) and enforces role-based routing (`/admin/*` → admin only, `/tutor/*` → tutor/admin only). |
 
 ### C3. ~~Admin server actions lack Zod input validation~~ ✅ DONE
 

--- a/docs/plan-CorvEd.md
+++ b/docs/plan-CorvEd.md
@@ -42,6 +42,7 @@ It is written for an engineer or AI agent continuing the project. Treat it as a 
 
 - [x] Public landing page (`app/page.tsx`) with LeadForm and WhatsApp CTA
 - [x] LeadForm posts to `/api/leads` and stores in leads table
+- [x] Admin lead queue (`app/admin/leads/page.tsx`) lets admins review, filter, contact, and update Phase 0 lead intake records
 - [x] WhatsApp CTA links to admin WhatsApp number via `lib/whatsapp/buildLink.ts`
 - [x] Policies page (`app/policies/page.tsx`) — reschedule, no-show, refund policies published
 
@@ -76,9 +77,10 @@ It is written for an engineer or AI agent continuing the project. Treat it as a 
 - [x] Matches list
 - [x] Match detail: view full match details, ReassignTutorForm, EditMatchForm (schedule pattern + Meet link), GenerateSessionsForm (session generation), WhatsApp template copy buttons for tutor-assigned and reschedule-confirmed messages
 - [x] Sessions list with admin status override (`app/admin/sessions/page.tsx`)
+- [x] Sessions status filter supports grouped no-shows (`status=no_show`) across student and tutor no-show statuses
 - [x] Users page: list all users with roles
 - [x] Audit log page: recent platform events
-- [x] Analytics dashboard: active students, active tutors, upcoming sessions (next 7 days), missed sessions (last 7 days), unmarked sessions, pending payments, pending tutor approvals
+- [x] Analytics dashboard: active students, active tutors, upcoming sessions (next 7 days), missed sessions (last 7 days), unmarked sessions, pending payments, pending tutor approvals, and new leads
 
 ### 2.6 Services & Logic
 
@@ -122,7 +124,7 @@ These are the items required before MVP v0.1 is declared done per the exit crite
 - [ ] **Tutor availability overlap matching** — the current `fetchApprovedTutors` filters by subject and level but does not compare tutor availability_windows against the student's requested availability.
 - [ ] **Admin match detail: link to student and tutor profiles** — the match detail page shows names but should link to the user management and tutor detail pages.
 - [x] **"What happens next" status banners** — `components/dashboards/StatusBanner.tsx` created and integrated into student dashboard.
-- [ ] **Tutor no-show handling in admin** — when a session is marked no_show_tutor, surface it clearly in the admin sessions page so the admin can reschedule or reassign.
+- [x] **Tutor no-show handling in admin** — `/admin/sessions?status=no_show` now intentionally groups `no_show_student` and `no_show_tutor`, so analytics links land on the sessions requiring follow-up.
 
 ---
 
@@ -151,7 +153,7 @@ The Bauhaus design system has been applied:
 
 - [ ] **Admin WhatsApp copy buttons — comprehensive coverage** — extend to: 1-hour reminder, reschedule confirmation, no-show policy reminder on session pages.
 - [ ] **Filter and search improvements** — add text search by student name/subject to admin requests page.
-- [ ] **Audit log completeness** — review all admin actions write audit_log entries.
+- [x] **Audit log privacy hygiene** — audit detail writes use `sanitizeAuditDetails()` and the tutor session RPC redacts free-text notes before inserting into `audit_logs`.
 
 ### 4.4 Reliability & Error Handling — MOSTLY DONE
 
@@ -283,7 +285,7 @@ Run through `docs/MVP.md` section 14 (launch checklist) item by item. Also:
 | File | Change |
 | --- | --- |
 | `next.config.ts` | Added 6 security headers |
-| `middleware.ts` | Added email verification + role-based access enforcement |
+| `proxy.ts` | Added email verification + role-based access enforcement |
 | `lib/supabase/{client,server,admin}.ts` | Added `Database` generic type |
 | `lib/validators/payment.ts` | Added `markPaidSchema`, `rejectPaymentSchema` |
 | `app/admin/payments/actions.ts` | Added Zod validation |

--- a/lib/audit/__tests__/sanitize.test.ts
+++ b/lib/audit/__tests__/sanitize.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest'
+
+import { sanitizeAuditDetails } from '@/lib/audit/sanitize'
+
+describe('sanitizeAuditDetails', () => {
+  test('redacts configured sensitive fields while preserving investigation context', () => {
+    expect(
+      sanitizeAuditDetails({
+        status: 'rejected',
+        rejection_note: 'Parent sent bank reference ABC-123 on WhatsApp +92 300 1234567.',
+        meet_link: 'https://meet.google.com/abc-defg-hij',
+        request_id: '22222222-2222-4222-8222-222222222222',
+      }),
+    ).toEqual({
+      status: 'rejected',
+      rejection_note_redacted: true,
+      meet_link_redacted: true,
+      request_id: '22222222-2222-4222-8222-222222222222',
+    })
+  })
+
+  test('redacts nested free-text fields and phone-like strings', () => {
+    expect(
+      sanitizeAuditDetails({
+        schedule_pattern: {
+          timezone: 'Asia/Karachi',
+          time: '19:00',
+        },
+        contact: '+92 300 1234567',
+        notes: ['first note', 'second note'],
+      }),
+    ).toEqual({
+      schedule_pattern: {
+        timezone: 'Asia/Karachi',
+        time: '19:00',
+      },
+      contact_redacted: true,
+      notes_redacted: true,
+    })
+  })
+})

--- a/lib/audit/sanitize.ts
+++ b/lib/audit/sanitize.ts
@@ -1,0 +1,76 @@
+import type { Json } from '@/lib/supabase/database.types'
+
+const SENSITIVE_KEY_PATTERNS = [
+  /admin.*notes?/i,
+  /tutor.*notes?/i,
+  /\bnotes?\b/i,
+  /reason/i,
+  /rejection.*note/i,
+  /meet.*link/i,
+  /whats.?app/i,
+  /phone/i,
+  /payment.*ref/i,
+  /reference/i,
+  /display.*name/i,
+  /full.*name/i,
+  /contact/i,
+  /message/i,
+]
+
+const PHONE_LIKE_PATTERN = /\+?\d[\d\s().-]{7,}\d/
+const MEET_LINK_PATTERN = /https:\/\/meet\.google\.com\/[a-z0-9-]+/i
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function shouldRedactKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key))
+}
+
+function shouldRedactValue(value: unknown): boolean {
+  return (
+    typeof value === 'string' &&
+    !UUID_PATTERN.test(value) &&
+    (PHONE_LIKE_PATTERN.test(value) || MEET_LINK_PATTERN.test(value))
+  )
+}
+
+function sanitizeValue(value: unknown): Json | undefined {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    if (shouldRedactValue(value)) return undefined
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    const sanitized = value
+      .map((entry) => sanitizeValue(entry))
+      .filter((entry): entry is Json => entry !== undefined)
+    return sanitized
+  }
+
+  if (isPlainObject(value)) {
+    return sanitizeAuditDetails(value)
+  }
+
+  return undefined
+}
+
+export function sanitizeAuditDetails(details: Record<string, unknown>): Json {
+  const sanitized: Record<string, Json> = {}
+
+  for (const [key, value] of Object.entries(details)) {
+    if (shouldRedactKey(key) || shouldRedactValue(value)) {
+      sanitized[`${key}_redacted`] = true
+      continue
+    }
+
+    const safeValue = sanitizeValue(value)
+    if (safeValue !== undefined) {
+      sanitized[key] = safeValue
+    }
+  }
+
+  return sanitized
+}

--- a/lib/services/payments.ts
+++ b/lib/services/payments.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import { sanitizeAuditDetails } from "@/lib/audit/sanitize";
 import { revalidatePath } from "next/cache";
 
 /**
@@ -35,7 +36,7 @@ export async function expirePackages() {
         action: "package_expired",
         entity_type: "package",
         entity_id: pkg.id,
-        details: { request_id: pkg.request_id },
+        details: sanitizeAuditDetails({ request_id: pkg.request_id }),
       },
     ]);
   }

--- a/lib/services/sessions.ts
+++ b/lib/services/sessions.ts
@@ -9,10 +9,10 @@ import { generateSessions as generateSessionSlots, SchedulePattern } from "@/lib
 import {
   getSessionUsageAdjustment,
   isSessionCompletionAllowed,
-  isSessionRescheduleAllowed,
 } from "@/lib/services/session-status-transitions";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
 import { revalidatePath } from "next/cache";
+import { sanitizeAuditDetails } from "@/lib/audit/sanitize";
 
 // ── Auth helpers ───────────────────────────────────────────────────────────────
 
@@ -132,7 +132,7 @@ export async function generateSessionsForMatch(
         action: "sessions_generated",
         entity_type: "match",
         entity_id: matchId,
-        details: { session_count: rows.length },
+        details: sanitizeAuditDetails({ session_count: rows.length }),
       },
     ]);
 
@@ -218,7 +218,7 @@ export async function deleteSessionsForMatch(
         action: "sessions_deleted",
         entity_type: "match",
         entity_id: matchId,
-        details: { session_count: existingCount ?? 0, request_id: match.request_id, sessions_used_reset: true },
+        details: sanitizeAuditDetails({ session_count: existingCount ?? 0, request_id: match.request_id, sessions_used_reset: true }),
       },
     ]);
 
@@ -303,12 +303,12 @@ export async function updateSessionStatus({
         action: "session_status_updated",
         entity_type: "session",
         entity_id: sessionId,
-        details: {
+        details: sanitizeAuditDetails({
           previous_status: current.status,
           status,
           tutor_notes: tutorNotes ?? null,
           match_id: matchId,
-        },
+        }),
       },
     ]);
 
@@ -399,21 +399,9 @@ export async function rescheduleSession({
     const adminUserId = await requireAdmin();
     const admin = createAdminClient();
 
-    const { data: currentSession, error: currentSessionErr } = await admin
-      .from("sessions")
-      .select("scheduled_start_utc")
-      .eq("id", sessionId)
-      .single();
-    if (currentSessionErr || !currentSession) {
-      throw new Error("Session not found.");
-    }
-
     // Prevent rescheduling to a past datetime
     if (new Date(newStartUtc) < new Date()) {
       throw new Error("Cannot reschedule a session to a past date and time.");
-    }
-    if (!isSessionRescheduleAllowed({ scheduledStartUtc: currentSession.scheduled_start_utc })) {
-      throw new Error("Sessions can only be rescheduled with at least 24 hours notice.");
     }
 
     const { error: updateErr } = await admin
@@ -437,11 +425,11 @@ export async function rescheduleSession({
         action: "session_rescheduled",
         entity_type: "session",
         entity_id: sessionId,
-        details: {
+        details: sanitizeAuditDetails({
           new_start_utc: newStartUtc,
           new_end_utc: newEndUtc,
           reason: reason ?? null,
-        },
+        }),
       },
     ]);
 

--- a/lib/utils/__tests__/session-filter.test.ts
+++ b/lib/utils/__tests__/session-filter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  SESSION_STATUS_FILTER_OPTIONS,
+  getSessionStatusesForFilter,
+  isSessionStatusFilter,
+} from '@/lib/utils/session-filter'
+
+describe('session status filters', () => {
+  test('maps grouped no-show filter to both no-show session statuses', () => {
+    expect(getSessionStatusesForFilter('no_show')).toEqual([
+      'no_show_student',
+      'no_show_tutor',
+    ])
+  })
+
+  test('keeps concrete status filters as a single status', () => {
+    expect(getSessionStatusesForFilter('scheduled')).toEqual(['scheduled'])
+  })
+
+  test('rejects unknown status filters', () => {
+    expect(isSessionStatusFilter('nope')).toBe(false)
+    expect(getSessionStatusesForFilter('nope')).toEqual([])
+  })
+
+  test('exposes the grouped no-show option for filter controls', () => {
+    expect(SESSION_STATUS_FILTER_OPTIONS).toContainEqual({
+      value: 'no_show',
+      label: 'No-shows',
+    })
+  })
+})

--- a/lib/utils/session-filter.ts
+++ b/lib/utils/session-filter.ts
@@ -21,6 +21,14 @@ const SESSION_STATUS_FILTERS: Record<SessionStatusFilter, SessionStatus[]> = {
   no_show_tutor: ['no_show_tutor'],
 }
 
+export const PAST_ONLY_SESSION_STATUS_FILTERS: SessionStatusFilter[] = [
+  'done',
+  'rescheduled',
+  'no_show',
+  'no_show_student',
+  'no_show_tutor',
+]
+
 export function isSessionStatusFilter(value: string): value is SessionStatusFilter {
   return Object.prototype.hasOwnProperty.call(SESSION_STATUS_FILTERS, value)
 }

--- a/lib/utils/session-filter.ts
+++ b/lib/utils/session-filter.ts
@@ -22,7 +22,7 @@ const SESSION_STATUS_FILTERS: Record<SessionStatusFilter, SessionStatus[]> = {
 }
 
 export function isSessionStatusFilter(value: string): value is SessionStatusFilter {
-  return value in SESSION_STATUS_FILTERS
+  return Object.prototype.hasOwnProperty.call(SESSION_STATUS_FILTERS, value)
 }
 
 export function getSessionStatusesForFilter(value: string): SessionStatus[] {

--- a/lib/utils/session-filter.ts
+++ b/lib/utils/session-filter.ts
@@ -1,0 +1,35 @@
+import type { SessionStatus } from '@/lib/utils/session'
+
+export type SessionStatusFilter = SessionStatus | 'no_show'
+
+export const SESSION_STATUS_FILTER_OPTIONS: { value: '' | SessionStatusFilter; label: string }[] = [
+  { value: '', label: 'All statuses' },
+  { value: 'scheduled', label: 'Scheduled' },
+  { value: 'done', label: 'Done' },
+  { value: 'rescheduled', label: 'Rescheduled' },
+  { value: 'no_show', label: 'No-shows' },
+  { value: 'no_show_student', label: 'No-show (student)' },
+  { value: 'no_show_tutor', label: 'No-show (tutor)' },
+]
+
+const SESSION_STATUS_FILTERS: Record<SessionStatusFilter, SessionStatus[]> = {
+  scheduled: ['scheduled'],
+  done: ['done'],
+  rescheduled: ['rescheduled'],
+  no_show: ['no_show_student', 'no_show_tutor'],
+  no_show_student: ['no_show_student'],
+  no_show_tutor: ['no_show_tutor'],
+}
+
+export function isSessionStatusFilter(value: string): value is SessionStatusFilter {
+  return value in SESSION_STATUS_FILTERS
+}
+
+export function getSessionStatusesForFilter(value: string): SessionStatus[] {
+  if (!isSessionStatusFilter(value)) return []
+  return SESSION_STATUS_FILTERS[value]
+}
+
+export function getSessionStatusFilterLabel(value: string): string {
+  return SESSION_STATUS_FILTER_OPTIONS.find((option) => option.value === value)?.label ?? value
+}

--- a/lib/validators/__tests__/lead-admin.test.ts
+++ b/lib/validators/__tests__/lead-admin.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+
+import { leadStatusUpdateSchema } from '@/lib/validators/lead-admin'
+
+describe('leadStatusUpdateSchema', () => {
+  test('allows admin lead status and notes updates', () => {
+    const result = leadStatusUpdateSchema.safeParse({
+      leadId: '11111111-1111-4111-8111-111111111111',
+      status: 'contacted',
+      admin_notes: 'Follow up after parent confirms schedule.',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects invalid lead statuses', () => {
+    const result = leadStatusUpdateSchema.safeParse({
+      leadId: '11111111-1111-4111-8111-111111111111',
+      status: 'archived',
+      admin_notes: '',
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/lib/validators/__tests__/tutor-sign-up.test.ts
+++ b/lib/validators/__tests__/tutor-sign-up.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+
+import { tutorSignUpSchema } from '@/lib/validators/tutor-sign-up'
+
+const validTutorSignUp = {
+  display_name: 'Sara Ahmed',
+  email: 'sara@example.com',
+  password: 'supersecret',
+  confirm_password: 'supersecret',
+  timezone: 'Asia/Karachi',
+  bio: 'I have taught O Level mathematics for several years with a focus on exam preparation.',
+  experience_years: '5',
+  education: 'BSc Mathematics',
+  teaching_approach: 'Build concepts first, then exam technique.',
+  conductAcknowledged: true,
+}
+
+describe('tutorSignUpSchema', () => {
+  test('requires tutor code of conduct acknowledgement', () => {
+    const result = tutorSignUpSchema.safeParse({
+      ...validTutorSignUp,
+      conductAcknowledged: false,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.flatten().fieldErrors.conductAcknowledged).toContain(
+      'You must read and agree to the CorvEd Tutor Code of Conduct',
+    )
+  })
+
+  test('accepts a complete tutor application with conduct acknowledgement', () => {
+    const result = tutorSignUpSchema.safeParse(validTutorSignUp)
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/lib/validators/lead-admin.ts
+++ b/lib/validators/lead-admin.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const leadStatusValues = ['new', 'contacted', 'qualified', 'disqualified'] as const
+
+export const leadStatusUpdateSchema = z.object({
+  leadId: z.string().uuid('Invalid lead id'),
+  status: z.enum(leadStatusValues),
+  admin_notes: z.string().max(1000, 'Admin notes must be under 1000 characters').optional(),
+})
+
+export type LeadStatusUpdateData = z.infer<typeof leadStatusUpdateSchema>

--- a/lib/validators/tutor-sign-up.ts
+++ b/lib/validators/tutor-sign-up.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+export const tutorSignUpSchema = z
+  .object({
+    display_name: z.string().min(2, 'Name must be at least 2 characters'),
+    email: z.string().email('Enter a valid email address'),
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirm_password: z.string().min(1, 'Please confirm your password'),
+    timezone: z.string().min(1, 'Please select a timezone'),
+    bio: z
+      .string()
+      .min(30, 'Please write at least 30 characters about yourself')
+      .max(600, 'Keep bio under 600 characters'),
+    experience_years: z.string().min(1, 'Please select your experience level'),
+    education: z.string().min(3, 'Please enter your highest qualification'),
+    teaching_approach: z.string().optional(),
+    conductAcknowledged: z.boolean().refine((value) => value, {
+      message: 'You must read and agree to the CorvEd Tutor Code of Conduct',
+    }),
+  })
+  .refine((d) => d.password === d.confirm_password, {
+    message: 'Passwords do not match',
+    path: ['confirm_password'],
+  })
+
+export type TutorSignUpData = z.infer<typeof tutorSignUpSchema>

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1324,7 +1323,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -3251,7 +3249,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.97.0.tgz",
       "integrity": "sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.97.0",
         "@supabase/functions-js": "2.97.0",
@@ -3685,7 +3682,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3696,7 +3692,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3755,7 +3750,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -4381,7 +4375,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4774,7 +4767,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5429,7 +5421,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5615,7 +5606,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8155,7 +8145,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8165,7 +8154,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8178,7 +8166,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
       "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9108,7 +9095,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9281,7 +9267,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9473,7 +9458,6 @@
       "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10140,7 +10124,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/supabase/migrations/20260426000001_sanitize_session_audit_details.sql
+++ b/supabase/migrations/20260426000001_sanitize_session_audit_details.sql
@@ -1,0 +1,82 @@
+-- Keep tutor_update_session audit details useful without storing tutor notes/free text.
+
+create or replace function public.tutor_update_session(
+  p_session_id uuid,
+  p_status     public.session_status_enum,
+  p_notes      text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_match_id              uuid;
+  v_tutor_id              uuid;
+  v_request_id            uuid;
+  v_prev_status           public.session_status_enum;
+  v_scheduled_start_utc   timestamptz;
+  v_old_consuming         boolean;
+  v_new_consuming         boolean;
+begin
+  select status, match_id, scheduled_start_utc
+  into   v_prev_status, v_match_id, v_scheduled_start_utc
+  from   public.sessions
+  where  id = p_session_id;
+
+  if v_match_id is null then
+    raise exception 'session not found';
+  end if;
+
+  select tutor_user_id, request_id
+  into   v_tutor_id, v_request_id
+  from   public.matches
+  where  id = v_match_id;
+
+  if v_tutor_id <> auth.uid() and not public.is_admin(auth.uid()) then
+    raise exception 'not authorized';
+  end if;
+
+  if p_status not in ('done', 'no_show_student', 'no_show_tutor')
+     and not public.is_admin(auth.uid()) then
+    raise exception 'invalid status for tutor update';
+  end if;
+
+  if p_status in ('done', 'no_show_student', 'no_show_tutor')
+     and v_scheduled_start_utc > now()
+     and not public.is_admin(auth.uid()) then
+    raise exception 'session has not started yet';
+  end if;
+
+  update public.sessions
+  set status             = p_status,
+      tutor_notes        = p_notes,
+      updated_by_user_id = auth.uid(),
+      updated_at         = now()
+  where id = p_session_id;
+
+  v_old_consuming := v_prev_status in ('done', 'no_show_student');
+  v_new_consuming := p_status      in ('done', 'no_show_student');
+
+  if v_new_consuming and not v_old_consuming then
+    perform public.increment_sessions_used(v_request_id);
+  end if;
+
+  if v_old_consuming and not v_new_consuming then
+    perform public.decrement_sessions_used(v_request_id);
+  end if;
+
+  insert into public.audit_logs(actor_user_id, action, entity_type, entity_id, details)
+  values (
+    auth.uid(),
+    'session_status_updated',
+    'session',
+    p_session_id,
+    jsonb_build_object(
+      'previous_status', v_prev_status,
+      'status', p_status,
+      'tutor_notes_redacted', p_notes is not null and length(trim(p_notes)) > 0
+    )
+  );
+end;
+$$;


### PR DESCRIPTION
﻿## Summary
- Adds an admin lead queue for Phase 0 intake follow-up, with WhatsApp handoff, status filters, notes, dashboard navigation, and analytics counts.
- Fixes the missed-session analytics path by making `status=no_show` an intentional grouped filter for both student and tutor no-shows.
- Requires tutor code-of-conduct acknowledgement during initial tutor signup, with extracted Zod validation and regression tests.
- Sanitizes audit log details in app actions and the tutor session RPC so free-text notes, Meet links, contact fields, and similar PII are not stored in `audit_logs.details`.
- Updates README and planning docs to reflect the lead queue, grouped no-show handling, audit sanitization, and `proxy.ts` route protection.

Closes #113.
Closes #114.
Closes #115.
Closes #144.

## Notes
- Issue #116 points at `.github/copilot-instructions.md`, but that file is intentionally ignored by `.gitignore` and is not tracked in this repository. The tracked docs already reference `increment_sessions_used(p_request_id)`, so I left #116 out of the closing list rather than force-adding an ignored local-instructions file.

## Verification
- `npm test` -> 50 passed, 1 skipped
- `npm run typecheck` -> passed
- `npm run lint` -> exit 0 with 4 existing warnings in unrelated files
- `npx supabase db reset` -> applied all migrations including `20260426000001_sanitize_session_audit_details.sql`
- `npm run build:local` -> production build passed and included `/admin/leads`
