### PR TITLE
Harden payment proof and session accounting checks

### DIFF
--- a/app/dashboard/packages/[id]/page.tsx
+++ b/app/dashboard/packages/[id]/page.tsx
@@ -7,9 +7,12 @@ import { useEffect, useRef, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { PAYMENT_INSTRUCTIONS, PACKAGES } from '@/lib/config/pricing'
+import {
+  buildPaymentProofPath,
+  isAllowedPaymentProofType,
+  MAX_PAYMENT_PROOF_SIZE_BYTES,
+} from '@/lib/payments/proofs'
 import { LEVEL_LABELS } from '@/lib/utils/request'
-
-const MAX_PROOF_SIZE_BYTES = 5 * 1024 * 1024 // 5 MB
 
 type PackageRow = {
   id: string
@@ -138,24 +141,21 @@ export default function PackageDetailPage() {
     if (payment.status === 'rejected') {
       let newProofPath: string | null = payment.proof_path
       if (file) {
-        if (file.size > MAX_PROOF_SIZE_BYTES) {
+        if (file.size > MAX_PAYMENT_PROOF_SIZE_BYTES) {
           setError('File is too large. Maximum size is 5 MB.')
           setSubmitting(false)
           return
         }
-        const allowedTypes = ['image/jpeg', 'image/png', 'image/jpg', 'application/pdf']
-        if (!allowedTypes.includes(file.type)) {
+        if (!isAllowedPaymentProofType(file.type)) {
           setError('Only JPEG, PNG, or PDF files are allowed.')
           setSubmitting(false)
           return
         }
-        const lastDot = file.name.lastIndexOf('.')
-        const baseName = (lastDot > 0 ? file.name.slice(0, lastDot) : file.name)
-          .replace(/[^a-zA-Z0-9_-]/g, '_')
-          .slice(0, 60)
-        const ext = lastDot > 0 ? file.name.slice(lastDot).replace(/[^a-zA-Z0-9.]/g, '') : ''
-        const safeFileName = baseName + ext
-        const filePath = `${user.id}/${id}/${Date.now()}_${safeFileName}`
+        const filePath = buildPaymentProofPath({
+          userId: user.id,
+          packageId: id,
+          fileName: file.name,
+        })
         const { data: uploadData, error: uploadError } = await supabase.storage
           .from('payment-proofs')
           .upload(filePath, file)
@@ -192,26 +192,22 @@ export default function PackageDetailPage() {
 
     // Upload proof file if selected
     if (file) {
-      if (file.size > MAX_PROOF_SIZE_BYTES) {
+      if (file.size > MAX_PAYMENT_PROOF_SIZE_BYTES) {
         setError('File is too large. Maximum size is 5 MB.')
         setSubmitting(false)
         return
       }
-      const allowedTypes = ['image/jpeg', 'image/png', 'image/jpg', 'application/pdf']
-      if (!allowedTypes.includes(file.type)) {
+      if (!isAllowedPaymentProofType(file.type)) {
         setError('Only JPEG, PNG, or PDF files are allowed.')
         setSubmitting(false)
         return
       }
 
-      // Sanitize filename: preserve only the final extension, clean the base name
-      const lastDot = file.name.lastIndexOf('.')
-      const baseName = (lastDot > 0 ? file.name.slice(0, lastDot) : file.name)
-        .replace(/[^a-zA-Z0-9_-]/g, '_')
-        .slice(0, 60)
-      const ext = lastDot > 0 ? file.name.slice(lastDot).replace(/[^a-zA-Z0-9.]/g, '') : ''
-      const safeFileName = baseName + ext
-      const filePath = `${user.id}/${id}/${Date.now()}_${safeFileName}`
+      const filePath = buildPaymentProofPath({
+        userId: user.id,
+        packageId: id,
+        fileName: file.name,
+      })
       const { data: uploadData, error: uploadError } = await supabase.storage
         .from('payment-proofs')
         .upload(filePath, file)

--- a/app/dashboard/packages/actions.ts
+++ b/app/dashboard/packages/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import { PACKAGES, type PackageTier } from '@/lib/config/pricing'
+import { isPaymentProofPathForPackage } from '@/lib/payments/proofs'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 
@@ -37,7 +38,11 @@ export async function getPaymentProofSignedUrl(
     return { url: null, error: 'Unauthorized' }
   }
 
-  if (!payment.proof_path || payment.proof_path !== proofPath) {
+  if (
+    !payment.proof_path
+    || payment.proof_path !== proofPath
+    || !isPaymentProofPathForPackage({ proofPath, userId: user.id, packageId })
+  ) {
     return { url: null, error: 'Proof not found' }
   }
 
@@ -113,6 +118,17 @@ export async function updatePendingPaymentDetails(
     return { success: false, error: 'Payment is not in pending status' }
   }
 
+  if (
+    proofPath
+    && !isPaymentProofPathForPackage({
+      proofPath,
+      userId: user.id,
+      packageId: payment.package_id,
+    })
+  ) {
+    return { success: false, error: 'Invalid proof path' }
+  }
+
   const admin = createAdminClient()
   const { data: updated, error } = await admin
     .from('payments')
@@ -158,7 +174,7 @@ export async function resubmitRejectedPayment(
   // Verify the user owns this payment and it's rejected
   const { data: payment } = await supabase
     .from('payments')
-    .select('id, payer_user_id, status')
+    .select('id, package_id, payer_user_id, status')
     .eq('id', paymentId)
     .single()
 
@@ -168,6 +184,17 @@ export async function resubmitRejectedPayment(
 
   if (payment.status !== 'rejected') {
     return { success: false, error: 'Payment is not in rejected status' }
+  }
+
+  if (
+    proofPath
+    && !isPaymentProofPathForPackage({
+      proofPath,
+      userId: user.id,
+      packageId: payment.package_id,
+    })
+  ) {
+    return { success: false, error: 'Invalid proof path' }
   }
 
   const admin = createAdminClient()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # CorvEd architecture
 
-Last updated: 2026-04-27
+Last updated: 2026-04-27  
 Stack: Next.js (App Router) + Supabase (Postgres + Auth + Storage)  
 Primary market: Pakistan, supports overseas students (timezone-aware)  
 Primary comms: WhatsApp (manual or WhatsApp Business), platform is source of truth

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # CorvEd architecture
 
-Last updated: 2026-02-22  
+Last updated: 2026-04-27
 Stack: Next.js (App Router) + Supabase (Postgres + Auth + Storage)  
 Primary market: Pakistan, supports overseas students (timezone-aware)  
 Primary comms: WhatsApp (manual or WhatsApp Business), platform is source of truth
@@ -830,6 +830,11 @@ visibility: private
 
 payment-proofs/{payer_user_id}/{package_id}/{timestamp}_{original_filename}
 
+Application code validates this convention before saving or signing a proof path:
+- folder 1 must equal the authenticated payer user id
+- folder 2 must equal the package id for the payment being updated/viewed
+- a file name segment must exist
+
 7.3 policies
 
 insert: payer can upload into their folder
@@ -859,7 +864,11 @@ proofs remain private
 
 admin UI uses server-side signed URLs to view proofs
 
-student UI does not need to view proof after upload
+student UI uses server-side signed URLs after ownership and package-path validation
+
+Verification command:
+
+node scripts/with-local-supabase-env.mjs npm test -- supabase/__tests__/payment-session-integrity.integration.test.ts
 
 8) key workflows (sequence-level detail)
 

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -27,7 +27,7 @@
 | | |
 |---|---|
 | **Severity** | Critical |
-| **Status** | **RESOLVED** — `app/dashboard/packages/actions.ts` provides `getPaymentProofSignedUrl()` server action that verifies ownership and creates 300s signed URLs. `app/dashboard/packages/[id]/page.tsx` updated to use it. |
+| **Status** | **RESOLVED** — `app/dashboard/packages/actions.ts` provides `getPaymentProofSignedUrl()` server action that verifies ownership, package path binding, and creates 300s signed URLs. `supabase/__tests__/payment-session-integrity.integration.test.ts` verifies private bucket owner/admin access and cross-user denial against local Supabase. |
 
 ### A2. ~~`PAYMENT_INSTRUCTIONS` contains placeholder values~~ ✅ DONE
 
@@ -59,7 +59,7 @@
 | | |
 |---|---|
 | **Severity** | Critical |
-| **Status** | **RESOLVED** — Migration `20260303000001_fix_double_increment_guard.sql` replaces the RPC with a guarded version that checks previous status before incrementing/decrementing. Also adds `decrement_sessions_used` helper. |
+| **Status** | **RESOLVED** — Migration `20260303000001_fix_double_increment_guard.sql` replaces the RPC with a guarded version that checks previous status before incrementing/decrementing. Also adds `decrement_sessions_used` helper. Local Supabase integration tests now verify double-submit stability, consuming/non-consuming transitions, service-role direct increments, and future-session blocking. |
 
 ### B2. ~~Documentation says `p_package_id` but code uses `p_request_id`~~ ✅ DONE
 

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -1,6 +1,6 @@
 # CorvEd MVP
 
-Last updated: 2026-02-22
+Last updated: 2026-04-27
 Owner: Taleef
 Market: Pakistan-first, with support for overseas students from day 1
 Primary comms: WhatsApp (WhatsApp-first operations)
@@ -156,6 +156,7 @@ These policies are locked for MVP.
 - reschedule requests are initiated via WhatsApp to admin
 - admin updates the session time in the platform
 - rescheduled sessions must still occur within the same package month window (unless admin makes an explicit exception)
+- launch decision: the admin tool warns for sessions inside the 24-hour cutoff but does not hard-block an operator. Late exceptions are admin-discretion only and must be recorded in the reschedule reason/audit trail.
 
 5.4 no-show policy
 Student no-show
@@ -527,6 +528,9 @@ Quality checks
   - parent signup → request A Level Math 8 sessions → pay → match → schedule → 2 sessions done → 1 student no-show → check remaining count
 - check timezone display for an overseas user (example: US Central)
 - verify reschedule cutoff logic is documented and applied in ops workflow (automation optional)
+- run local Supabase integrity checks:
+  - `npx supabase db reset`
+  - `node scripts/with-local-supabase-env.mjs npm test -- supabase/__tests__/payment-session-integrity.integration.test.ts`
 
 --------------------------------------------------------------------------------
 

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -1,6 +1,6 @@
 # CorvEd Ops
 
-Last updated: 2026-04-27
+Last updated: 2026-04-27  
 Owner: Taleef  
 Market: Pakistan-first + overseas students  
 Primary comms: WhatsApp (WhatsApp Business recommended)  

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -1,6 +1,6 @@
 # CorvEd Ops
 
-Last updated: 2026-02-22  
+Last updated: 2026-04-27
 Owner: Taleef  
 Market: Pakistan-first + overseas students  
 Primary comms: WhatsApp (WhatsApp Business recommended)  
@@ -259,7 +259,7 @@ Steps:
    - send confirmation with updated time
 3) if < 24 hours:
    - apply policy (see section 5)
-   - if you grant exception, log it in audit note (platform or Ops log)
+   - if you grant exception, enter a clear reason in the admin reschedule form so the platform audit log captures why the cutoff was overridden
 
 Minimum success condition:
 - platform session is updated correctly
@@ -346,8 +346,8 @@ You may allow exceptions for:
 
 When granting an exception:
 - do it consistently
-- record it:
-  - add an internal admin note and/or audit log entry
+- record it in the admin reschedule reason before saving the new session time
+- do not use WhatsApp alone as the exception record
 
 --------------------------------------------------------------------------------
 

--- a/docs/plan-CorvEd.md
+++ b/docs/plan-CorvEd.md
@@ -113,8 +113,8 @@ These are the items required before MVP v0.1 is declared done per the exit crite
 ### 3.1 Must-Have (MVP v0.1 Blockers) — MOSTLY ADDRESSED
 
 - [x] **Email verification enforcement** — middleware now checks email verification status and redirects unverified email/password users to `/auth/verify`.
-- [ ] **Payment proof storage RLS** — confirm the Supabase Storage bucket for payment proofs has correct RLS policies so only the owner and admin can read a proof file. The signed URL approach (A1 fix) provides defense in depth.
-- [ ] **Session count correctness end-to-end test** — manual verification still needed. Double-increment guard (B1) now protects the RPC. Unit tests for scheduling logic added.
+- [x] **Payment proof storage RLS** — local Supabase integration tests now confirm the `payment-proofs` bucket is private, owner/admin signed URL access works, cross-user read/signed URL attempts fail, and proof paths must match `{payer_user_id}/{package_id}/...`.
+- [x] **Session count correctness end-to-end test** — local Supabase integration tests cover `increment_sessions_used`, `decrement_sessions_used`, `tutor_update_session`, double-submit stability, consuming/non-consuming transitions, service-role direct RPC use, and future-session completion blocking.
 - [ ] **Overseas timezone display smoke test** — sign in as a user with timezone America/New_York, confirm the next session card and sessions list display times in that timezone (not UTC or PKT).
 - [ ] **Admin can set Meet link and it appears on student + tutor dashboards** — trace the data flow from the EditMatchForm through to the NextSessionCard and tutor session list to confirm the meet_link field is displayed correctly.
 - [x] **Package renewal alert** — PackageSummary at ≤3 sessions. Admin analytics now shows renewal alerts via `getExpiringPackages(5)`.
@@ -159,7 +159,7 @@ The Bauhaus design system has been applied:
 
 - [x] **Form validation feedback** — Zod validation in admin server actions (C3). Inline errors + toast for outcomes.
 - [ ] **Supabase error surface** — wrap all Supabase calls in try/catch consistently. Partially done.
-- [ ] **Package/payment idempotency** — confirm payment creation prevents duplicates.
+- [x] **Package/payment idempotency** — local Supabase integration tests confirm repeated checkout returns the existing package/payment and rejected-proof resubmission only updates the intended rejected payment.
 
 ### 4.5 Testing — ✅ DONE
 
@@ -167,7 +167,7 @@ Test infrastructure established:
 
 - [x] **Unit tests for scheduling logic** — `lib/services/__tests__/scheduling.test.ts` with 11 tests covering: session count, tier limits, date range, 31-day months, UTC conversion for PKT, DST handling (US Eastern), invalid timezone, invalid time format, empty results, duration calculation. All passing.
 - [x] **Unit tests for rate-limit logic** — `lib/__tests__/rate-limit.test.ts` with 4 tests. All passing.
-- [ ] **Unit tests for session count logic** — DB trigger tests need local Supabase running.
+- [x] **Integration tests for session count logic** — `supabase/__tests__/payment-session-integrity.integration.test.ts` runs against local Supabase and verifies RPC usage accounting.
 - [ ] **Integration smoke tests** — E2E flow test still needed (Playwright infrastructure exists).
 
 ---
@@ -233,7 +233,7 @@ Vitest infrastructure established. 15 unit tests (11 scheduling, 4 rate-limit), 
 Run through `docs/MVP.md` section 14 (launch checklist) item by item. Also:
 - Install and configure Sentry (F2)
 - Set real bank details in env vars (A2)
-- Verify payment proof bucket RLS
+- Verify payment proof bucket RLS using `node scripts/with-local-supabase-env.mjs npm test -- supabase/__tests__/payment-session-integrity.integration.test.ts`
 - Run manual E2E scenario
 - 375px mobile responsiveness audit
 
@@ -299,4 +299,4 @@ Run through `docs/MVP.md` section 14 (launch checklist) item by item. Also:
 
 ---
 
-End of plan. Last updated: 2026-03-03.
+End of plan. Last updated: 2026-04-27.

--- a/lib/payments/__tests__/proofs.test.ts
+++ b/lib/payments/__tests__/proofs.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildPaymentProofPath,
+  isAllowedPaymentProofType,
+  isPaymentProofPathForPackage,
+  sanitizePaymentProofFileName,
+} from '@/lib/payments/proofs'
+
+describe('payment proof path helpers', () => {
+  test('builds private proof paths under the payer and package prefix', () => {
+    expect(
+      buildPaymentProofPath({
+        userId: 'user-123',
+        packageId: 'pkg-456',
+        fileName: 'Transfer receipt #42.pdf',
+        timestamp: 12345,
+      }),
+    ).toBe('user-123/pkg-456/12345_Transfer_receipt__42.pdf')
+  })
+
+  test('sanitizes file names without dropping the final extension', () => {
+    expect(sanitizePaymentProofFileName(' bank / receipt (final).png')).toBe(
+      '_bank___receipt__final_.png',
+    )
+    expect(sanitizePaymentProofFileName('')).toBe('proof')
+  })
+
+  test('accepts only expected upload mime types', () => {
+    expect(isAllowedPaymentProofType('image/jpeg')).toBe(true)
+    expect(isAllowedPaymentProofType('application/pdf')).toBe(true)
+    expect(isAllowedPaymentProofType('image/svg+xml')).toBe(false)
+  })
+
+  test('requires proof paths to match the payment owner and package', () => {
+    expect(
+      isPaymentProofPathForPackage({
+        proofPath: 'user-123/pkg-456/12345_receipt.pdf',
+        userId: 'user-123',
+        packageId: 'pkg-456',
+      }),
+    ).toBe(true)
+
+    expect(
+      isPaymentProofPathForPackage({
+        proofPath: 'user-123/other-package/12345_receipt.pdf',
+        userId: 'user-123',
+        packageId: 'pkg-456',
+      }),
+    ).toBe(false)
+
+    expect(
+      isPaymentProofPathForPackage({
+        proofPath: 'other-user/pkg-456/12345_receipt.pdf',
+        userId: 'user-123',
+        packageId: 'pkg-456',
+      }),
+    ).toBe(false)
+  })
+})

--- a/lib/payments/proofs.ts
+++ b/lib/payments/proofs.ts
@@ -1,0 +1,60 @@
+export const MAX_PAYMENT_PROOF_SIZE_BYTES = 5 * 1024 * 1024
+
+export const PAYMENT_PROOF_ALLOWED_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/jpg',
+  'application/pdf',
+] as const
+
+export type PaymentProofMimeType = (typeof PAYMENT_PROOF_ALLOWED_TYPES)[number]
+
+export function isAllowedPaymentProofType(type: string): type is PaymentProofMimeType {
+  return PAYMENT_PROOF_ALLOWED_TYPES.includes(type as PaymentProofMimeType)
+}
+
+export function sanitizePaymentProofFileName(fileName: string): string {
+  const lastDot = fileName.lastIndexOf('.')
+  const baseName = (lastDot > 0 ? fileName.slice(0, lastDot) : fileName)
+    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .slice(0, 60)
+  const extension = lastDot > 0 ? fileName.slice(lastDot).replace(/[^a-zA-Z0-9.]/g, '') : ''
+  const safeBaseName = baseName || 'proof'
+
+  return `${safeBaseName}${extension}`
+}
+
+export function buildPaymentProofPath({
+  userId,
+  packageId,
+  fileName,
+  timestamp = Date.now(),
+}: {
+  userId: string
+  packageId: string
+  fileName: string
+  timestamp?: number
+}): string {
+  return `${userId}/${packageId}/${timestamp}_${sanitizePaymentProofFileName(fileName)}`
+}
+
+export function isPaymentProofPathForPackage({
+  proofPath,
+  userId,
+  packageId,
+}: {
+  proofPath: string | null
+  userId: string
+  packageId: string
+}): boolean {
+  if (!proofPath) return false
+
+  const trimmedPath = proofPath.replace(/^\/+/, '')
+  const [pathUserId, pathPackageId, ...fileParts] = trimmedPath.split('/')
+  const fileName = fileParts.join('/')
+
+  return pathUserId === userId
+    && pathPackageId === packageId
+    && fileName.length > 0
+    && !fileParts.includes('..')
+}

--- a/supabase/__tests__/payment-session-integrity.integration.test.ts
+++ b/supabase/__tests__/payment-session-integrity.integration.test.ts
@@ -251,11 +251,11 @@ describeLocal('payment proof storage, checkout idempotency, and session RPCs', (
       .remove([proofPath])
     expect(deleteError).toBeNull()
 
-    const { data: stillPrivateProof, error: stillPrivateProofError } = await student.client.storage
+    const { data: deletedProof, error: deletedProofError } = await student.client.storage
       .from('payment-proofs')
       .download(proofPath)
-    expect(stillPrivateProofError).toBeNull()
-    expect(await stillPrivateProof?.text()).toBe('proof')
+    expect(deletedProofError).toBeTruthy()
+    expect(deletedProof).toBeNull()
   })
 
   test('keeps checkout and rejected-payment resubmission idempotent', async () => {

--- a/supabase/__tests__/payment-session-integrity.integration.test.ts
+++ b/supabase/__tests__/payment-session-integrity.integration.test.ts
@@ -1,0 +1,452 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/supabase/database.types'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+const hasLocalSupabaseEnv = Boolean(supabaseUrl && anonKey && serviceRoleKey)
+const describeLocal = hasLocalSupabaseEnv ? describe : describe.skip
+
+type SupabaseClient = ReturnType<typeof createClient<Database>>
+type TestUser = {
+  client: SupabaseClient
+  email: string
+  userId: string
+}
+
+describeLocal('payment proof storage, checkout idempotency, and session RPCs', () => {
+  const password = 'LocalIntegrityTest!12345'
+  const unique = Date.now()
+
+  let admin: SupabaseClient
+  let adminUser: TestUser
+  let student: TestUser
+  let otherStudent: TestUser
+  let tutor: TestUser
+  let subjectId: number
+
+  beforeAll(async () => {
+    admin = createClient<Database>(supabaseUrl!, serviceRoleKey!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+
+    const { data: subject, error: subjectError } = await admin
+      .from('subjects')
+      .select('id')
+      .eq('active', true)
+      .limit(1)
+      .single()
+    if (subjectError || !subject) throw subjectError ?? new Error('No active subject found')
+    subjectId = subject.id
+
+    adminUser = await createTestUser('admin', 'Admin Operator')
+    student = await createTestUser('student', 'Integrity Student')
+    otherStudent = await createTestUser('student', 'Other Student')
+    tutor = await createTestUser('tutor', 'Integrity Tutor')
+  })
+
+  async function createTestUser(
+    role: Database['public']['Enums']['role_enum'],
+    displayName: string,
+  ): Promise<TestUser> {
+    const email = `${role}-${unique}-${crypto.randomUUID()}@example.com`
+    const { data: created, error: createError } = await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name: displayName, timezone: 'Asia/Karachi' },
+    })
+    if (createError || !created.user) {
+      throw createError ?? new Error(`Failed to create ${role} user`)
+    }
+
+    const userId = created.user.id
+
+    const { error: profileError } = await admin.from('user_profiles').upsert({
+      user_id: userId,
+      display_name: displayName,
+      whatsapp_number: '+923001234567',
+      timezone: 'Asia/Karachi',
+      primary_role: role,
+    })
+    if (profileError) throw profileError
+
+    const { error: roleError } = await admin
+      .from('user_roles')
+      .upsert({ user_id: userId, role })
+    if (roleError) throw roleError
+
+    if (role === 'tutor') {
+      const { error: tutorError } = await admin.from('tutor_profiles').upsert({
+        tutor_user_id: userId,
+        approved: true,
+        bio: 'Integration test tutor',
+        timezone: 'Asia/Karachi',
+      })
+      if (tutorError) throw tutorError
+    }
+
+    const client = createClient<Database>(supabaseUrl!, anonKey!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+    const { error: signInError } = await client.auth.signInWithPassword({ email, password })
+    if (signInError) throw signInError
+
+    return { client, email, userId }
+  }
+
+  async function createStudentRequest(client = student.client, userId = student.userId) {
+    const { data: request, error: requestError } = await client
+      .from('requests')
+      .insert({
+        created_by_user_id: userId,
+        requester_role: 'student',
+        level: 'o_levels',
+        subject_id: subjectId,
+        exam_board: 'unspecified',
+        timezone: 'Asia/Karachi',
+        availability_windows: [],
+      })
+      .select('id')
+      .single()
+    if (requestError || !request) throw requestError ?? new Error('Failed to create request')
+
+    return request.id
+  }
+
+  async function checkoutRequest(requestId: string) {
+    const { data: packageId, error: checkoutError } = await student.client.rpc('checkout_package', {
+      p_request_id: requestId,
+      p_tier_sessions: 8,
+    })
+    if (checkoutError || !packageId) {
+      throw checkoutError ?? new Error('Failed to checkout package')
+    }
+
+    const { data: payment, error: paymentError } = await admin
+      .from('payments')
+      .select('id')
+      .eq('package_id', packageId)
+      .single()
+    if (paymentError || !payment) throw paymentError ?? new Error('Failed to load payment')
+
+    return { packageId, paymentId: payment.id }
+  }
+
+  async function createActiveSessionFixture() {
+    const requestId = await createStudentRequest()
+    const { data: pkg, error: packageError } = await admin
+      .from('packages')
+      .insert({
+        request_id: requestId,
+        tier_sessions: 8,
+        start_date: '2026-04-01',
+        end_date: '2026-04-30',
+        sessions_total: 8,
+        sessions_used: 0,
+        status: 'active',
+      })
+      .select('id')
+      .single()
+    if (packageError || !pkg) throw packageError ?? new Error('Failed to create package')
+
+    await admin.from('requests').update({ status: 'active' }).eq('id', requestId)
+
+    const { data: match, error: matchError } = await admin
+      .from('matches')
+      .insert({
+        request_id: requestId,
+        tutor_user_id: tutor.userId,
+        assigned_by_user_id: adminUser.userId,
+        status: 'active',
+        meet_link: 'https://meet.google.com/abc-defg-hij',
+        schedule_pattern: {
+          timezone: 'Asia/Karachi',
+          days: [1],
+          time: '19:00',
+          duration_mins: 60,
+        },
+      })
+      .select('id')
+      .single()
+    if (matchError || !match) throw matchError ?? new Error('Failed to create match')
+
+    const { data: session, error: sessionError } = await admin
+      .from('sessions')
+      .insert({
+        match_id: match.id,
+        scheduled_start_utc: '2026-04-01T12:00:00.000Z',
+        scheduled_end_utc: '2026-04-01T13:00:00.000Z',
+        status: 'scheduled',
+      })
+      .select('id')
+      .single()
+    if (sessionError || !session) throw sessionError ?? new Error('Failed to create session')
+
+    return { requestId, packageId: pkg.id, sessionId: session.id }
+  }
+
+  async function getPackageUsage(packageId: string) {
+    const { data, error } = await admin
+      .from('packages')
+      .select('sessions_used')
+      .eq('id', packageId)
+      .single()
+    if (error || !data) throw error ?? new Error('Failed to load package usage')
+
+    return data.sessions_used
+  }
+
+  test('keeps payment proof bucket private and grants proof access only to owner/admin', async () => {
+    const { data: bucket, error: bucketError } = await admin.storage.getBucket('payment-proofs')
+    expect(bucketError).toBeNull()
+    expect(bucket?.public).toBe(false)
+
+    const requestId = await createStudentRequest()
+    const { packageId, paymentId } = await checkoutRequest(requestId)
+    const proofPath = `${student.userId}/${packageId}/proof.txt`
+
+    const { error: uploadError } = await student.client.storage
+      .from('payment-proofs')
+      .upload(proofPath, new Blob(['proof']))
+    expect(uploadError).toBeNull()
+
+    const { error: crossPrefixUploadError } = await otherStudent.client.storage
+      .from('payment-proofs')
+      .upload(`${student.userId}/${packageId}/intrusion.txt`, new Blob(['intrusion']))
+    expect(crossPrefixUploadError).toBeTruthy()
+
+    const { error: paymentUpdateError } = await student.client
+      .from('payments')
+      .update({ proof_path: proofPath, reference: 'proof-owner' })
+      .eq('id', paymentId)
+    expect(paymentUpdateError).toBeNull()
+
+    const { data: ownerSignedUrl, error: ownerSignedUrlError } = await student.client.storage
+      .from('payment-proofs')
+      .createSignedUrl(proofPath, 300)
+    expect(ownerSignedUrlError).toBeNull()
+    expect(ownerSignedUrl?.signedUrl).toContain('/storage/v1/object/sign/payment-proofs/')
+
+    const { error: otherDownloadError } = await otherStudent.client.storage
+      .from('payment-proofs')
+      .download(proofPath)
+    expect(otherDownloadError).toBeTruthy()
+
+    const { error: otherSignedUrlError } = await otherStudent.client.storage
+      .from('payment-proofs')
+      .createSignedUrl(proofPath, 300)
+    expect(otherSignedUrlError).toBeTruthy()
+
+    const { data: adminSignedUrl, error: adminSignedUrlError } = await admin.storage
+      .from('payment-proofs')
+      .createSignedUrl(proofPath, 300)
+    expect(adminSignedUrlError).toBeNull()
+    expect(adminSignedUrl?.signedUrl).toContain('/storage/v1/object/sign/payment-proofs/')
+
+    const { error: deleteError } = await student.client.storage
+      .from('payment-proofs')
+      .remove([proofPath])
+    expect(deleteError).toBeNull()
+
+    const { data: stillPrivateProof, error: stillPrivateProofError } = await student.client.storage
+      .from('payment-proofs')
+      .download(proofPath)
+    expect(stillPrivateProofError).toBeNull()
+    expect(await stillPrivateProof?.text()).toBe('proof')
+  })
+
+  test('keeps checkout and rejected-payment resubmission idempotent', async () => {
+    const requestId = await createStudentRequest()
+    const { packageId, paymentId } = await checkoutRequest(requestId)
+
+    const { data: repeatedPackageId, error: repeatedCheckoutError } = await student.client.rpc(
+      'checkout_package',
+      {
+        p_request_id: requestId,
+        p_tier_sessions: 8,
+      },
+    )
+    expect(repeatedCheckoutError).toBeNull()
+    expect(repeatedPackageId).toBe(packageId)
+
+    const { count: paymentCount, error: paymentCountError } = await admin
+      .from('payments')
+      .select('id', { count: 'exact', head: true })
+      .eq('package_id', packageId)
+    expect(paymentCountError).toBeNull()
+    expect(paymentCount).toBe(1)
+
+    const secondRequestId = await createStudentRequest()
+    const { packageId: secondPackageId, paymentId: secondPaymentId } = await checkoutRequest(
+      secondRequestId,
+    )
+
+    const oldProofPath = `${student.userId}/${packageId}/old-proof.txt`
+    const newProofPath = `${student.userId}/${packageId}/new-proof.txt`
+    const untouchedProofPath = `${student.userId}/${secondPackageId}/untouched-proof.txt`
+
+    const { error: rejectError } = await admin
+      .from('payments')
+      .update({
+        status: 'rejected',
+        proof_path: oldProofPath,
+        reference: 'old-reference',
+        rejection_note: 'Unreadable proof',
+        verified_by_user_id: adminUser.userId,
+        verified_at: new Date().toISOString(),
+      })
+      .eq('id', paymentId)
+    expect(rejectError).toBeNull()
+
+    const { error: untouchedUpdateError } = await admin
+      .from('payments')
+      .update({ proof_path: untouchedProofPath, reference: 'untouched' })
+      .eq('id', secondPaymentId)
+    expect(untouchedUpdateError).toBeNull()
+
+    const { data: wronglyScopedUpdate, error: wronglyScopedUpdateError } = await admin
+      .from('payments')
+      .update({ proof_path: newProofPath })
+      .eq('id', secondPaymentId)
+      .eq('payer_user_id', otherStudent.userId)
+      .eq('status', 'rejected')
+      .select('id')
+    expect(wronglyScopedUpdateError).toBeNull()
+    expect(wronglyScopedUpdate).toEqual([])
+
+    const { data: resubmitted, error: resubmitError } = await admin
+      .from('payments')
+      .update({
+        status: 'pending',
+        proof_path: newProofPath,
+        reference: 'new-reference',
+        rejection_note: null,
+        verified_by_user_id: null,
+        verified_at: null,
+      })
+      .eq('id', paymentId)
+      .eq('payer_user_id', student.userId)
+      .eq('status', 'rejected')
+      .select('id, proof_path, status')
+    expect(resubmitError).toBeNull()
+    expect(resubmitted).toEqual([{ id: paymentId, proof_path: newProofPath, status: 'pending' }])
+
+    const { data: secondPayment, error: secondPaymentError } = await admin
+      .from('payments')
+      .select('proof_path, reference, status')
+      .eq('id', secondPaymentId)
+      .single()
+    expect(secondPaymentError).toBeNull()
+    expect(secondPayment).toMatchObject({
+      proof_path: untouchedProofPath,
+      reference: 'untouched',
+      status: 'pending',
+    })
+  })
+
+  test('keeps session usage accounting stable across RPC transitions', async () => {
+    const { packageId, sessionId } = await createActiveSessionFixture()
+
+    const { error: doneError } = await tutor.client.rpc('tutor_update_session', {
+      p_session_id: sessionId,
+      p_status: 'done',
+      p_notes: 'Completed first pass',
+    })
+    expect(doneError).toBeNull()
+    expect(await getPackageUsage(packageId)).toBe(1)
+
+    const { error: repeatDoneError } = await tutor.client.rpc('tutor_update_session', {
+      p_session_id: sessionId,
+      p_status: 'done',
+      p_notes: 'Duplicate submit',
+    })
+    expect(repeatDoneError).toBeNull()
+    expect(await getPackageUsage(packageId)).toBe(1)
+
+    const { error: studentNoShowError } = await tutor.client.rpc('tutor_update_session', {
+      p_session_id: sessionId,
+      p_status: 'no_show_student',
+      p_notes: 'Student missed class',
+    })
+    expect(studentNoShowError).toBeNull()
+    expect(await getPackageUsage(packageId)).toBe(1)
+
+    const { error: tutorNoShowError } = await tutor.client.rpc('tutor_update_session', {
+      p_session_id: sessionId,
+      p_status: 'no_show_tutor',
+      p_notes: 'Tutor missed class',
+    })
+    expect(tutorNoShowError).toBeNull()
+    expect(await getPackageUsage(packageId)).toBe(0)
+
+    const { error: rescheduledByTutorError } = await tutor.client.rpc('tutor_update_session', {
+      p_session_id: sessionId,
+      p_status: 'rescheduled',
+      p_notes: 'Tutor attempted reschedule',
+    })
+    expect(rescheduledByTutorError).toBeTruthy()
+
+    const { error: consumingAgainError } = await tutor.client.rpc('tutor_update_session', {
+      p_session_id: sessionId,
+      p_status: 'no_show_student',
+      p_notes: 'Consume before admin reschedule',
+    })
+    expect(consumingAgainError).toBeNull()
+    expect(await getPackageUsage(packageId)).toBe(1)
+
+    const { error: adminRescheduleError } = await adminUser.client.rpc('tutor_update_session', {
+      p_session_id: sessionId,
+      p_status: 'rescheduled',
+      p_notes: 'Admin exception reschedule',
+    })
+    expect(adminRescheduleError).toBeNull()
+    expect(await getPackageUsage(packageId)).toBe(0)
+  })
+
+  test('protects session usage RPC permissions and future-session completion', async () => {
+    const { requestId, packageId } = await createActiveSessionFixture()
+
+    const { error: directStudentIncrementError } = await student.client.rpc(
+      'increment_sessions_used',
+      { p_request_id: requestId },
+    )
+    expect(directStudentIncrementError).toBeTruthy()
+    expect(await getPackageUsage(packageId)).toBe(0)
+
+    await admin.from('packages').update({ sessions_total: 2 }).eq('id', packageId)
+
+    const firstAdminIncrement = await admin.rpc('increment_sessions_used', {
+      p_request_id: requestId,
+    })
+    const secondAdminIncrement = await admin.rpc('increment_sessions_used', {
+      p_request_id: requestId,
+    })
+    const cappedAdminIncrement = await admin.rpc('increment_sessions_used', {
+      p_request_id: requestId,
+    })
+    expect(firstAdminIncrement.error).toBeNull()
+    expect(secondAdminIncrement.error).toBeNull()
+    expect(cappedAdminIncrement.error).toBeNull()
+    expect(await getPackageUsage(packageId)).toBe(2)
+
+    const futureFixture = await createActiveSessionFixture()
+    await admin
+      .from('sessions')
+      .update({
+        scheduled_start_utc: '2999-04-01T12:00:00.000Z',
+        scheduled_end_utc: '2999-04-01T13:00:00.000Z',
+      })
+      .eq('id', futureFixture.sessionId)
+
+    const { error: futureCompletionError } = await tutor.client.rpc('tutor_update_session', {
+      p_session_id: futureFixture.sessionId,
+      p_status: 'done',
+      p_notes: 'Too early',
+    })
+    expect(futureCompletionError?.message).toContain('session has not started yet')
+    expect(await getPackageUsage(futureFixture.packageId)).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Harden payment proof handling so saved/signed proof paths must match the authenticated payer and package prefix.
- Add shared payment-proof upload/path helpers with unit coverage, and reuse them from the package detail flow.
- Add local Supabase integration coverage for private payment proof storage, checkout idempotency, rejected-proof resubmission scoping, session usage RPC transitions, RPC permissions, and future-session completion blocking.
- Update launch/docs status for payment proof RLS, package/payment idempotency, session accounting verification, and the 24-hour reschedule cutoff decision.

## Verification
- `npx supabase db reset`
- `npm test -- lib/payments/__tests__/proofs.test.ts lib/services/__tests__/session-status-transitions.test.ts`
- `node scripts/with-local-supabase-env.mjs npm test -- supabase/__tests__/payment-session-integrity.integration.test.ts supabase/__tests__/lifecycle-rls.integration.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint` (passes with 4 existing warnings in unrelated files)
- `node scripts/with-local-supabase-env.mjs npm run build`
- `git diff --check`

Closes #120
Closes #138
Closes #139
Closes #145